### PR TITLE
Handle 500 server error on password reset page

### DIFF
--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -16,6 +16,8 @@ import { validatePassword } from './data/service';
 import InvalidTokenMessage from './InvalidToken';
 import ResetSuccessMessage from './ResetSuccess';
 import Spinner from './Spinner';
+import APIFailureMessage from '../common-components/APIFailureMessage';
+import { INTERNAL_SERVER_ERROR } from '../data/constants';
 
 const ResetPasswordPage = (props) => {
   const { intl } = props;
@@ -78,8 +80,16 @@ const ResetPasswordPage = (props) => {
       props.validateToken(token);
       return <Spinner />;
     }
-  } else if (props.token_status === 'invalid') {
+  } else if (props.token_status === 'invalid' && props.errorCode !== INTERNAL_SERVER_ERROR) {
     return <InvalidTokenMessage />;
+  } else if (props.token_status === 'invalid' && props.errorCode === INTERNAL_SERVER_ERROR) {
+    return (
+      <div className="d-flex justify-content-center m-4">
+        <div className="d-flex flex-column mw-500">
+          <APIFailureMessage header={intl.formatMessage(messages['reset.password.token.validation.sever.error'])} />
+        </div>
+      </div>
+    );
   } else if (props.status === 'success') {
     return <ResetSuccessMessage />;
   } else {
@@ -87,13 +97,14 @@ const ResetPasswordPage = (props) => {
       <>
         <div id="main" className="d-flex justify-content-center m-4">
           <div className="d-flex flex-column mw-500">
-            {(emptyFieldError || props.status) && (
+            {(emptyFieldError || props.status) && (!props.errorCode) && (
               <Alert id="validation-errors" variant="danger">
                 <Alert.Heading>{intl.formatMessage(messages['forgot.password.empty.new.password.error.heading'])}</Alert.Heading>
                 <ul><li>{emptyFieldError || props.errors}</li></ul>
               </Alert>
             )}
             <Form>
+              {props.errorCode === INTERNAL_SERVER_ERROR ? <APIFailureMessage header={intl.formatMessage(messages['reset.password.request.server.error'])} /> : null}
               <h3 className="mt-3">
                 {intl.formatMessage(messages['reset.password.page.heading'])}
               </h3>
@@ -161,6 +172,7 @@ ResetPasswordPage.defaultProps = {
   token: null,
   match: null,
   errors: null,
+  errorCode: null,
 };
 
 ResetPasswordPage.propTypes = {
@@ -168,6 +180,7 @@ ResetPasswordPage.propTypes = {
   resetPassword: PropTypes.func.isRequired,
   validateToken: PropTypes.func.isRequired,
   token_status: PropTypes.string,
+  errorCode: PropTypes.string,
   token: PropTypes.string,
   match: PropTypes.shape({
     params: PropTypes.shape({

--- a/src/reset-password/data/actions.js
+++ b/src/reset-password/data/actions.js
@@ -18,9 +18,9 @@ export const validateTokenSuccess = (tokenStatus, token) => ({
   payload: { tokenStatus, token },
 });
 
-export const validateTokenFailure = (tokenStatus) => ({
+export const validateTokenFailure = (tokenStatus, errorCode) => ({
   type: VALIDATE_TOKEN.FAILURE,
-  payload: { tokenStatus },
+  payload: { tokenStatus, errorCode },
 });
 
 // Reset Password
@@ -38,7 +38,7 @@ export const resetPasswordSuccess = data => ({
   payload: { data },
 });
 
-export const resetPasswordFailure = errors => ({
+export const resetPasswordFailure = (errors, errorCode) => ({
   type: RESET_PASSWORD.FAILURE,
-  payload: { errors },
+  payload: { errors, errorCode },
 });

--- a/src/reset-password/data/reducers.js
+++ b/src/reset-password/data/reducers.js
@@ -24,6 +24,7 @@ const reducer = (state = defaultState, action = null) => {
       return {
         ...state,
         token_status: 'invalid',
+        errorCode: action.payload.errorCode,
       };
     case RESET_PASSWORD.BEGIN:
       return {
@@ -40,6 +41,7 @@ const reducer = (state = defaultState, action = null) => {
         ...state,
         status: 'failure',
         errors: action.payload.errors,
+        errorCode: action.payload.errorCode,
       };
     default:
       return state;

--- a/src/reset-password/data/sagas.js
+++ b/src/reset-password/data/sagas.js
@@ -14,7 +14,7 @@ import {
 } from './actions';
 
 import { validateToken, resetPassword } from './service';
-
+import { INTERNAL_SERVER_ERROR } from '../../data/constants';
 // Services
 export function* handleValidateToken(action) {
   try {
@@ -27,7 +27,7 @@ export function* handleValidateToken(action) {
       yield put(validateTokenFailure(isValid));
     }
   } catch (err) {
-    yield put(validateTokenFailure(err));
+    yield put(validateTokenFailure(err, INTERNAL_SERVER_ERROR));
     logError(err);
   }
 }
@@ -45,7 +45,7 @@ export function* handleResetPassword(action) {
       yield put(resetPasswordFailure(resetErrors));
     }
   } catch (err) {
-    yield put(resetPasswordFailure(err));
+    yield put(resetPasswordFailure(err, INTERNAL_SERVER_ERROR));
     logError(err);
   }
 }

--- a/src/reset-password/messages.js
+++ b/src/reset-password/messages.js
@@ -61,6 +61,16 @@ const messages = defineMessages({
     defaultMessage: 'We couldn\'t reset your password.',
     description: 'Heading that appears above error message when user submits empty form.',
   },
+  'reset.password.request.server.error': {
+    id: 'reset.password.request.server.error',
+    defaultMessage: 'Failed to reset password',
+    description: 'Failed to reset password error message heading.',
+  },
+  'reset.password.token.validation.sever.error': {
+    id: 'reset.password.token.validation.sever.error',
+    defaultMessage: 'Token validation failure',
+    description: 'Failed to validate reset password token.',
+  },
 });
 
 export default messages;

--- a/src/reset-password/tests/ResetPasswordPage.test.jsx
+++ b/src/reset-password/tests/ResetPasswordPage.test.jsx
@@ -8,7 +8,7 @@ import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
 import CookiePolicyBanner from '@edx/frontend-component-cookie-policy-banner';
 import * as auth from '@edx/frontend-platform/auth';
 import { resetPassword } from '../data/actions';
-
+import { INTERNAL_SERVER_ERROR } from '../../data/constants';
 import ResetPasswordPage from '../ResetPasswordPage';
 
 jest.mock('../data/selectors', () => jest.fn().mockImplementation(() => ({ resetPasswordSelector: () => ({}) })));
@@ -202,6 +202,16 @@ describe('ResetPasswordPage', () => {
     );
 
     resetPasswordPage.unmount();
+  });
+
+  it('should show alert on server error', () => {
+    props = {
+      ...props,
+      token_status: 'invalid',
+      errorCode: INTERNAL_SERVER_ERROR,
+    };
+    const tree = mount(reduxWrapper(<IntlResetPasswordPage {...props} />));
+    expect(tree.find('div.alert-heading').text()).toEqual('Token validation failure');
   });
 
   it('should display empty new password field error', () => {


### PR DESCRIPTION
There is a need to handle 500 server errors on MFE so that they can be properly communicated with end-users.
Now, it looks like the following:
<img width="423" alt="Screen Shot 2021-01-27 at 7 42 59 PM" src="https://user-images.githubusercontent.com/15120237/106007243-e6b83880-60d7-11eb-9a24-851f516a2789.png">

VAN-281 