### PR TITLE
handle 500 on forgot password page

### DIFF
--- a/src/common-components/APIFailureMessage.jsx
+++ b/src/common-components/APIFailureMessage.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Alert } from '@edx/paragon';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import PropTypes from 'prop-types';
+import messages from './messages';
+
+const APIFailureMessage = (props) => {
+  const { intl, header } = props;
+
+  return (
+    <Alert variant="danger">
+      <Alert.Heading>
+        {header}
+      </Alert.Heading>
+      {intl.formatMessage(messages['internal.server.error.message'])}
+    </Alert>
+  );
+};
+
+APIFailureMessage.propTypes = {
+  intl: intlShape.isRequired,
+  header: PropTypes.string.isRequired,
+};
+
+export default injectIntl(APIFailureMessage);

--- a/src/common-components/messages.jsx
+++ b/src/common-components/messages.jsx
@@ -23,6 +23,11 @@ const messages = defineMessages({
                     + 'email address, or check your spam folder.',
     description: 'Part of message that appears after user requests password change',
   },
+  'internal.server.error.message': {
+    id: 'internal.server.error.message',
+    defaultMessage: 'An error has occurred. Try refreshing the page, or check your Internet connection.',
+    description: 'Error message that appears when server responds with 500 error code',
+  },
 });
 
 export default messages;

--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -18,6 +18,8 @@ import { forgotPasswordResultSelector } from './data/selectors';
 import RequestInProgressAlert from './RequestInProgressAlert';
 import { LOGIN_PAGE, VALID_EMAIL_REGEX } from '../data/constants';
 import LoginHelpLinks from '../login/LoginHelpLinks';
+import APIFailureMessage from '../common-components/APIFailureMessage';
+import { INTERNAL_SERVER_ERROR } from '../login/data/constants';
 
 const ForgotPasswordPage = (props) => {
   const { intl, status } = props;
@@ -36,6 +38,12 @@ const ForgotPasswordPage = (props) => {
     }
   };
 
+  const getStatusBannerifAny = () => {
+    if (status === INTERNAL_SERVER_ERROR) {
+      return <APIFailureMessage header={intl.formatMessage(messages['forgot.password.request.server.error'])} />;
+    }
+    return status === 'forbidden' ? <RequestInProgressAlert /> : null;
+  };
   sendPageEvent('login_and_registration', 'reset');
 
   return (
@@ -60,7 +68,7 @@ const ForgotPasswordPage = (props) => {
           <div className="d-flex justify-content-center m-4">
             <div className="d-flex flex-column">
               <Form className="mw-500">
-                {status === 'forbidden' ? <RequestInProgressAlert /> : null}
+                { getStatusBannerifAny()}
                 <h3 className="mt-3">
                   {intl.formatMessage(messages['forgot.password.page.heading'])}
                 </h3>

--- a/src/forgot-password/data/actions.js
+++ b/src/forgot-password/data/actions.js
@@ -20,3 +20,7 @@ export const forgotPasswordSuccess = email => ({
 export const forgotPasswordForbidden = () => ({
   type: FORGOT_PASSWORD.FORBIDDEN,
 });
+
+export const forgotPasswordServerError = () => ({
+  type: FORGOT_PASSWORD.FAILURE,
+});

--- a/src/forgot-password/data/reducers.js
+++ b/src/forgot-password/data/reducers.js
@@ -1,4 +1,5 @@
 import { FORGOT_PASSWORD } from './actions';
+import { INTERNAL_SERVER_ERROR } from '../../login/data/constants';
 
 export const defaultState = {
   status: null,
@@ -22,6 +23,11 @@ const reducer = (state = defaultState, action = null) => {
         return {
           ...state,
           status: 'forbidden',
+        };
+      case FORGOT_PASSWORD.FAILURE:
+        return {
+          ...state,
+          status: INTERNAL_SERVER_ERROR,
         };
       default:
         return state;

--- a/src/forgot-password/data/sagas.js
+++ b/src/forgot-password/data/sagas.js
@@ -6,6 +6,7 @@ import {
   forgotPasswordBegin,
   forgotPasswordSuccess,
   forgotPasswordForbidden,
+  forgotPasswordServerError,
 } from './actions';
 
 import { forgotPassword } from './service';
@@ -22,7 +23,7 @@ export function* handleForgotPassword(action) {
     if (e.response && e.response.status === 403) {
       yield put(forgotPasswordForbidden());
     } else {
-      throw e;
+      yield put(forgotPasswordServerError());
     }
   }
 }

--- a/src/forgot-password/messages.js
+++ b/src/forgot-password/messages.js
@@ -36,6 +36,11 @@ const messages = defineMessages({
     defaultMessage: 'Email must have at least 3 characters.',
     description: 'Invalid email address length message for the forgot password page.',
   },
+  'forgot.password.request.server.error': {
+    id: 'forgot.password.request.server.error',
+    defaultMessage: 'Failed to Send Forgot Password Email',
+    description: 'Failed to Send Forgot Password Email help text heading.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
There is a need to handle 500 server errors on MFE so that they can be properly communicated with end-users.
Now, it looks like the following:
<img width="508" alt="Screen Shot 2021-01-27 at 7 29 02 PM" src="https://user-images.githubusercontent.com/15120237/106006502-1d418380-60d7-11eb-9c64-b62ee7c16869.png">

VAN-281