### PR TITLE
password page email validation removed

### DIFF
--- a/src/forgot-password/messages.js
+++ b/src/forgot-password/messages.js
@@ -41,6 +41,20 @@ const messages = defineMessages({
     defaultMessage: 'Failed to Send Forgot Password Email',
     description: 'Failed to Send Forgot Password Email help text heading.',
   },
+  'forgot.password.invalid.email.heading': {
+    id: 'forgot.password.invalid.email',
+    defaultMessage: 'An error occurred.',
+    description: 'heading for invalid email',
+  },
+  'forgot.password.invalid.email.message': {
+    id: 'forgot.password.invalid.email.message',
+    defaultMessage: "The email address you've provided isn't formatted correctly.",
+    description: 'message for invalid email',
+  },
+  'forgot.password.email.help.text': {
+    id: 'forgot.password.email.help.text',
+    defaultMessage: 'The email address you used to register with {platformName}',
+    description: 'text help for the email',
+  },
 });
-
 export default messages;

--- a/src/forgot-password/tests/ForgotPasswordPage.test.jsx
+++ b/src/forgot-password/tests/ForgotPasswordPage.test.jsx
@@ -91,13 +91,23 @@ describe('ForgotPasswordPage', () => {
   });
 
   it('should display email validation error message', async () => {
-    const validationMessage = "Email must have at least 3 characters. The email address you've provided isn't formatted correctly.";
+    const validationMessage = "The email address you've provided isn't formatted correctly.";
     const wrapper = mount(reduxWrapper(<IntlForgotPasswordPage {...props} />));
     await act(async () => {
-      await wrapper.find('input#forgot-password-input').simulate('change', { target: { value: '', name: 'email' } });
+      await wrapper.find('button.btn-primary').simulate('click', { target: { value: 'random', name: 'email' } });
     });
     wrapper.update();
     expect(wrapper.find('#email-invalid-feedback').text()).toEqual(validationMessage);
+  });
+
+  it('should display alert banner incase of invalid email', async () => {
+    const validationMessage = "An error occurred.The email address you've provided isn't formatted correctly.";
+    const wrapper = mount(reduxWrapper(<IntlForgotPasswordPage {...props} />));
+    await act(async () => {
+      await wrapper.find('button.btn-primary').simulate('click', { target: { value: 'random', name: 'email' } });
+    });
+    wrapper.update();
+    expect(wrapper.find('.alert-danger').text()).toEqual(validationMessage);
   });
 
   it('should handle 500 error code', async () => {

--- a/src/forgot-password/tests/__snapshots__/ForgotPasswordPage.test.jsx.snap
+++ b/src/forgot-password/tests/__snapshots__/ForgotPasswordPage.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`ForgotPasswordPage should match default section snapshot 1`] = `
           Email
         </label>
         <input
-          aria-describedby=""
+          aria-describedby="email-help-text"
           className="form-control"
           id="forgot-password-input"
           name="email"
@@ -39,11 +39,12 @@ exports[`ForgotPasswordPage should match default section snapshot 1`] = `
           type="email"
           value=""
         />
-        <p
-          className="mb-2"
+        <small
+          className="form-text text-muted"
+          id="email-help-text"
         >
-          The email address you used to register with edX.
-        </p>
+          The email address you used to register with edX
+        </small>
       </div>
       <button
         className="mt-1 field-link small"
@@ -159,7 +160,7 @@ exports[`ForgotPasswordPage should match forbidden section snapshot 1`] = `
           Email
         </label>
         <input
-          aria-describedby=""
+          aria-describedby="email-help-text"
           className="form-control"
           id="forgot-password-input"
           name="email"
@@ -168,11 +169,12 @@ exports[`ForgotPasswordPage should match forbidden section snapshot 1`] = `
           type="email"
           value=""
         />
-        <p
-          className="mb-2"
+        <small
+          className="form-text text-muted"
+          id="email-help-text"
         >
-          The email address you used to register with edX.
-        </p>
+          The email address you used to register with edX
+        </small>
       </div>
       <button
         className="mt-1 field-link small"
@@ -263,7 +265,7 @@ exports[`ForgotPasswordPage should match pending section snapshot 1`] = `
           Email
         </label>
         <input
-          aria-describedby=""
+          aria-describedby="email-help-text"
           className="form-control"
           id="forgot-password-input"
           name="email"
@@ -272,11 +274,12 @@ exports[`ForgotPasswordPage should match pending section snapshot 1`] = `
           type="email"
           value=""
         />
-        <p
-          className="mb-2"
+        <small
+          className="form-text text-muted"
+          id="email-help-text"
         >
-          The email address you used to register with edX.
-        </p>
+          The email address you used to register with edX
+        </small>
       </div>
       <button
         className="mt-1 field-link small"


### PR DESCRIPTION
van-316
Email validation removed `onChange` event.
Paragon helper text added.
Updated the error message incase of invalid email
<img width="1246" alt="Screen Shot 2021-02-02 at 12 15 15 PM" src="https://user-images.githubusercontent.com/8156837/106565266-5a32cd80-6550-11eb-9de2-d04c6ec5723b.png">
