### PR TITLE
fix bug: Error on correct password submission

### DIFF
--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -32,12 +32,12 @@ const ResetPasswordPage = (props) => {
   const [bannerErrorMessage, setbannerErrorMessage] = useState('');
 
   useEffect(() => {
-    if (props.errors) {
+    if (props.status === 'failure' && props.errors) {
       setbannerErrorMessage(props.errors);
       setvalidationMessage(props.errors);
       setPasswordValidValue(false);
     }
-  }, [props.status === 'failure']);
+  }, [props.status]);
 
   const validatePasswordFromBackend = async (newPassword) => {
     let errorMessage;

--- a/src/reset-password/tests/ResetPasswordPage.test.jsx
+++ b/src/reset-password/tests/ResetPasswordPage.test.jsx
@@ -224,6 +224,7 @@ describe('ResetPasswordPage', () => {
       token_status: 'valid',
       token: 'token',
       errors: validationMessage,
+      status: 'failure',
     };
 
     const resetPasswordPage = mount(reduxWrapper(<IntlResetPasswordPage {...props} />));


### PR DESCRIPTION
Currently if there is an error above the form field from previous tries, it is displayed under the field on correct password submission.