### PR TITLE
Add multiple enterprise redirect

### DIFF
--- a/src/common-components/RedirectLogistration.jsx
+++ b/src/common-components/RedirectLogistration.jsx
@@ -4,12 +4,14 @@ import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 
 function RedirectLogistration(props) {
-  const { finishAuthUrl, success, redirectUrl } = props;
+  const { finishAuthUrl, redirectUrl, success } = props;
 
   if (success) {
     // If we're in a third party auth pipeline, we must complete the pipeline
     // once user has successfully logged in. Otherwise, redirect to the specified redirect url.
-    if (finishAuthUrl) {
+    // Note: For multiple enterprise use case, we need to make sure that user first visits the
+    // enterprise selection page and then complete the auth workflow
+    if (finishAuthUrl && !redirectUrl.includes(finishAuthUrl)) {
       window.location.href = getConfig().LMS_BASE_URL + finishAuthUrl;
     } else {
       window.location.href = redirectUrl;

--- a/src/login/tests/LoginPage.test.jsx
+++ b/src/login/tests/LoginPage.test.jsx
@@ -249,6 +249,33 @@ describe('LoginPage', () => {
     expect(window.location.href).toBe(getConfig().LMS_BASE_URL + authCompleteUrl);
   });
 
+  it('should redirect to enterprise selection page', () => {
+    const authCompleteUrl = '/auth/complete/google-oauth2/';
+    const enterpriseSelectionPage = 'http://localhost:18000/enterprise/select/active/?success_url='.concat(authCompleteUrl);
+    store = mockStore({
+      ...initialState,
+      login: {
+        ...initialState.login,
+        loginResult: {
+          success: true,
+          redirectUrl: enterpriseSelectionPage,
+        },
+      },
+      commonComponents: {
+        ...initialState.commonComponents,
+        thirdPartyAuthContext: {
+          ...initialState.commonComponents.thirdPartyAuthContext,
+          finishAuthUrl: authCompleteUrl,
+        },
+      },
+    });
+
+    delete window.location;
+    window.location = { href: getConfig().BASE_URL };
+    renderer.create(reduxWrapper(<IntlLoginPage {...props} />));
+    expect(window.location.href).toBe(enterpriseSelectionPage);
+  });
+
   it('should redirect to social auth provider url', () => {
     const loginUrl = '/auth/login/apple-id/?auth_entry=login&next=/dashboard';
     store = mockStore({


### PR DESCRIPTION
If redirect url has auth complete url in it, it means that the redirect url is for multiple enterprise selection page and user must be redirected to that page first.

example url = http://localhost:18000/enterprise/select/active/?success_url=/auth/complete/google-oauth2/

This check mimics the [following scenario](https://github.com/edx/edx-platform/blob/50bb70298cd30170e5572dfd9e7d2914dec3a4cd/lms/static/js/student_account/views/AccessView.js#L319-L320) from FE:
```javascript
 loginComplete: function() {
    if (this.thirdPartyAuth && this.thirdPartyAuth.finishAuthUrl) {
        multipleEnterpriseInterface.check(this.thirdPartyAuth.finishAuthUrl);
        // Note: the third party auth URL likely contains another redirect URL embedded inside
    } else {
        multipleEnterpriseInterface.check(this.nextUrl);
    }
 },
```

[VAN-311](https://openedx.atlassian.net/browse/VAN-311)