### PR TITLE
Remove unused placeholder prop

### DIFF
--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -104,7 +104,6 @@ const ForgotPasswordPage = (props) => {
                   type="email"
                   invalid={validationError !== ''}
                   invalidMessage={validationError}
-                  placeholder="username@domain.com"
                   value={values.email}
                   onBlur={() => getValidationMessage(values.email)}
                   onChange={e => setFieldValue('email', e.target.value)}

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -494,7 +494,6 @@ class RegistrationPage extends React.Component {
               key={field.name}
               invalid={this.state.errors[stateVar] !== ''}
               invalidMessage={field.errorMessages.required}
-              placeholder=""
               className="mb-0"
               value={props.value}
               onClick={(e) => this.handleOnClick(e)}
@@ -555,7 +554,6 @@ class RegistrationPage extends React.Component {
               type={field.type}
               key={field.name}
               value={props.value}
-              placeholder=""
               className={cssClass}
               onClick={(e) => this.handleOnClick(e)}
               onChange={(e) => this.handleOnChange(e)}
@@ -686,7 +684,6 @@ class RegistrationPage extends React.Component {
                   type="text"
                   invalid={this.state.errors.name !== ''}
                   invalidMessage={this.state.errors.name}
-                  placeholder=""
                   value={this.state.name}
                   onClick={(e) => this.handleOnClick(e)}
                   onBlur={(e) => this.handleOnBlur(e)}
@@ -700,7 +697,6 @@ class RegistrationPage extends React.Component {
                   type="text"
                   invalid={this.state.errors.username !== ''}
                   invalidMessage={this.state.errors.username}
-                  placeholder=""
                   value={this.state.username}
                   onClick={(e) => this.handleOnClick(e)}
                   onBlur={(e) => this.handleOnBlur(e)}
@@ -714,7 +710,6 @@ class RegistrationPage extends React.Component {
                   type="text"
                   invalid={this.state.errors.email !== ''}
                   invalidMessage={this.state.errors.email}
-                  placeholder=""
                   value={this.state.email}
                   onClick={(e) => this.handleOnClick(e)}
                   onBlur={(e) => this.handleOnBlur(e)}
@@ -729,7 +724,6 @@ class RegistrationPage extends React.Component {
                     type="password"
                     invalid={this.state.errors.password !== ''}
                     invalidMessage={this.state.errors.password}
-                    placeholder=""
                     value={this.state.password}
                     onClick={(e) => this.handleOnClick(e)}
                     onBlur={(e) => this.handleOnBlur(e)}
@@ -744,7 +738,6 @@ class RegistrationPage extends React.Component {
                   name="optional"
                   type="checkbox"
                   invalidMessage=""
-                  placeholder=""
                   value={this.state.enableOptionalField}
                   onClick={(e) => this.handleOnOptional(e)}
                   onBlur={null}

--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -130,7 +130,6 @@ const ResetPasswordPage = (props) => {
                 type="password"
                 invalid={!passwordValid}
                 invalidMessage={validationMessage}
-                placeholder=""
                 value={newPasswordInput}
                 onChange={e => handleNewPasswordChange(e)}
                 onBlur={e => handleNewPasswordOnBlur(e)}
@@ -143,7 +142,6 @@ const ResetPasswordPage = (props) => {
                 type="password"
                 invalid={!passwordMatch}
                 invalidMessage={intl.formatMessage(messages['reset.password.page.invalid.match.message'])}
-                placeholder=""
                 value={confirmPasswordInput}
                 onChange={e => handleConfirmPasswordChange(e)}
                 className="w-100"


### PR DESCRIPTION
`AuthnCustomValidationFormGroup` uses label as placeholder for input element instead of `placeholder` (It is also not part of the default props of the component).

https://github.com/edx/frontend-app-authn/blob/845b8c85fc8579a6be2318440658a935905b7ac3/src/common-components/AuthnValidationFormGroup.jsx#L63