### PR TITLE
Fix to let  tpa_hint url have ? instead of &

### DIFF
--- a/src/data/utils/dataUtils.js
+++ b/src/data/utils/dataUtils.js
@@ -25,3 +25,18 @@ export const getTpaProvider = (tpaHintProvider, primaryProviders, secondaryProvi
   }
   return tpaProvider;
 };
+
+export const processTpaHintURL = (params) => {
+  let tpaHint = null;
+  tpaHint = params.get('tpa_hint');
+  if (!tpaHint) {
+    const next = params.get('next');
+    if (next) {
+      const index = next.indexOf('tpa_hint=');
+      if (index !== -1) {
+        tpaHint = next.substring(index + 'tpa_hint='.length, next.length);
+      }
+    }
+  }
+  return tpaHint;
+};

--- a/src/data/utils/index.js
+++ b/src/data/utils/index.js
@@ -1,2 +1,2 @@
-export { default, getTpaProvider } from './dataUtils';
+export { default, getTpaProvider, processTpaHintURL } from './dataUtils';
 export { default as AsyncActionType } from './reduxUtils';

--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -31,7 +31,7 @@ import {
   DEFAULT_REDIRECT_URL, DEFAULT_STATE, LOGIN_PAGE, REGISTER_PAGE, ENTERPRISE_LOGIN_URL, PENDING_STATE,
 } from '../data/constants';
 import { forgotPasswordResultSelector } from '../forgot-password';
-import { getTpaProvider } from '../data/utils';
+import { getTpaProvider, processTpaHintURL } from '../data/utils';
 
 class LoginPage extends React.Component {
   constructor(props, context) {
@@ -52,11 +52,11 @@ class LoginPage extends React.Component {
 
   componentDidMount() {
     const params = (new URL(document.location)).searchParams;
-    const tpaHint = params.get('tpa_hint');
     const payload = {
       redirect_to: params.get('next') || DEFAULT_REDIRECT_URL,
     };
 
+    const tpaHint = processTpaHintURL(params);
     if (tpaHint) {
       payload.tpa_hint = tpaHint;
     }
@@ -266,7 +266,7 @@ class LoginPage extends React.Component {
 
     const params = (new URL(window.location.href)).searchParams;
 
-    const tpaHint = params.get('tpa_hint');
+    const tpaHint = processTpaHintURL(params);
     if (tpaHint) {
       if (thirdPartyAuthApiStatus === PENDING_STATE) {
         return <Skeleton height={36} />;

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -30,7 +30,7 @@ import EnterpriseSSO from '../common-components/EnterpriseSSO';
 import {
   DEFAULT_REDIRECT_URL, DEFAULT_STATE, LOGIN_PAGE, PENDING_STATE, REGISTER_PAGE,
 } from '../data/constants';
-import { getTpaProvider } from '../data/utils';
+import { getTpaProvider, processTpaHintURL } from '../data/utils';
 
 class RegistrationPage extends React.Component {
   constructor(props, context) {
@@ -73,11 +73,11 @@ class RegistrationPage extends React.Component {
 
   componentDidMount() {
     const params = (new URL(document.location)).searchParams;
-    const tpaHint = params.get('tpa_hint');
     const payload = {
       redirect_to: params.get('next') || DEFAULT_REDIRECT_URL,
     };
 
+    const tpaHint = processTpaHintURL(params);
     if (tpaHint) {
       payload.tpa_hint = tpaHint;
     }
@@ -583,7 +583,7 @@ class RegistrationPage extends React.Component {
     } = this.props.thirdPartyAuthContext;
 
     const params = (new URL(window.location.href)).searchParams;
-    const tpaHint = params.get('tpa_hint');
+    const tpaHint = processTpaHintURL(params);
 
     if (tpaHint) {
       if (thirdPartyAuthApiStatus === PENDING_STATE) {


### PR DESCRIPTION
Now the url could also be of the form
?next=/dashboard?tpa_hint=oa2-google-oauth2
to be backward compatible with old url.

VAN-42