### PR TITLE
VAN-393: use sentence case for text

### DIFF
--- a/src/common-components/messages.jsx
+++ b/src/common-components/messages.jsx
@@ -9,7 +9,7 @@ const messages = defineMessages({
   // Confirmation Alert Message
   'forgot.password.confirmation.title': {
     id: 'forgot.password.confirmation.title',
-    defaultMessage: 'Check Your Email',
+    defaultMessage: 'Check your email',
     description: 'Forgot password confirmation message title',
   },
   'forgot.password.confirmation.support.link': {

--- a/src/common-components/tests/ConfirmationAlert.test.jsx
+++ b/src/common-components/tests/ConfirmationAlert.test.jsx
@@ -21,7 +21,7 @@ describe('ConfirmationAlert', () => {
       </IntlProvider>,
     );
 
-    const expectedMessage = 'Check Your Email'
+    const expectedMessage = 'Check your email'
                             + 'You entered test@example.com. If this email address is associated with your edX account, '
                             + 'we will send a message with password recovery instructions to this email address.'
                             + 'If you do not receive a password reset message after 1 minute, verify that you entered '

--- a/src/forgot-password/messages.js
+++ b/src/forgot-password/messages.js
@@ -43,7 +43,7 @@ const messages = defineMessages({
   },
   'forgot.password.empty.email.field.error': {
     id: 'forgot.password.empty.email.field.error',
-    defaultMessage: 'Please enter your Email.',
+    defaultMessage: 'Please enter your email.',
     description: 'Error message that appears when user tries to submit empty email field',
   },
   'forgot.password.invalid.email.heading': {

--- a/src/forgot-password/tests/ForgotPasswordPage.test.jsx
+++ b/src/forgot-password/tests/ForgotPasswordPage.test.jsx
@@ -111,7 +111,7 @@ describe('ForgotPasswordPage', () => {
   });
 
   it('should display empty email validation message', async () => {
-    const validationMessage = 'Failed to send forgot password email.Please enter your Email.';
+    const validationMessage = 'Failed to send forgot password email.Please enter your email.';
     const forgotPasswordPage = mount(reduxWrapper(<IntlForgotPasswordPage {...props} />));
 
     await act(async () => { await forgotPasswordPage.find('button.btn-primary').simulate('click'); });
@@ -141,7 +141,7 @@ describe('ForgotPasswordPage', () => {
   });
 
   it('should display error message on blur event', async () => {
-    const validationMessage = 'Please enter your Email.';
+    const validationMessage = 'Please enter your email.';
     const forgotPasswordPage = mount(reduxWrapper(<IntlForgotPasswordPage {...props} />));
     const emailInput = forgotPasswordPage.find('input#forgot-password-input');
 

--- a/src/login/messages.jsx
+++ b/src/login/messages.jsx
@@ -18,7 +18,7 @@ const messages = defineMessages({
   },
   'other.sign.in.issues': {
     id: 'other.sign.in.issues',
-    defaultMessage: 'Other sign-in issues',
+    defaultMessage: 'Other sign in issues',
     description: 'A link that redirects to sign-in issues help',
   },
   'need.other.help.signing.in.collapsible.menu': {
@@ -48,13 +48,8 @@ const messages = defineMessages({
   },
   'create.an.account': {
     id: 'create.an.account',
-    defaultMessage: 'Create an Account',
+    defaultMessage: 'Create an account',
     description: 'Message on button to return to register page',
-  },
-  'institution.login.sign.in': {
-    id: 'institution.login.sign.in',
-    defaultMessage: 'Sign In',
-    description: 'Sign In text',
   },
   'or.sign.in.with': {
     id: 'or.sign.in.with',
@@ -98,12 +93,12 @@ const messages = defineMessages({
   },
   'email.validation.message': {
     id: 'email.validation.message',
-    defaultMessage: 'Please enter your Email.',
+    defaultMessage: 'Please enter your email.',
     description: 'Validation message that appears when email is empty',
   },
   'password.validation.message': {
     id: 'password.validation.message',
-    defaultMessage: 'Please enter your Password.',
+    defaultMessage: 'Please enter your password.',
     description: 'Validation message that appears when password is empty',
   },
   'password.label': {
@@ -118,8 +113,8 @@ const messages = defineMessages({
   },
   'sign.in.heading': {
     id: 'sign.in.heading',
-    defaultMessage: 'Sign In',
-    description: 'Sign In text',
+    defaultMessage: 'Sign in',
+    description: 'Sign in text',
   },
   // Account Activation Strings
   'account.activation.success.message.title': {
@@ -149,7 +144,7 @@ const messages = defineMessages({
   },
   'internal.server.error.message': {
     id: 'internal.server.error.message',
-    defaultMessage: 'An error has occurred. Try refreshing the page, or check your Internet connection.',
+    defaultMessage: 'An error has occurred. Try refreshing the page, or check your internet connection.',
     description: 'Error message that appears when server responds with 500 error code',
   },
   'login.rate.limit.reached.message': {
@@ -164,7 +159,7 @@ const messages = defineMessages({
   },
   'contact.support.link': {
     id: 'contact.support.link',
-    defaultMessage: 'contact {platformName} Support',
+    defaultMessage: 'contact {platformName} support',
     description: 'Link text used in inactive user error message to go to learner help center',
   },
   'login.failed.link.text': {

--- a/src/login/tests/LoginFailure.test.jsx
+++ b/src/login/tests/LoginFailure.test.jsx
@@ -58,7 +58,7 @@ describe('LoginFailureMessage', () => {
 
     const expectedMessage = 'We couldn\'t sign you in.In order to sign in, you need to activate your account. '
                             + 'We just sent an activation link to text@example.com. If you do not receive an email, '
-                            + 'check your spam folders or contact openedX Support.';
+                            + 'check your spam folders or contact openedX support.';
 
     expect(loginFailureMessage.find('#login-failure-alert').first().text()).toEqual(expectedMessage);
     expect(loginFailureMessage.find('#login-failure-alert').find('a').props().href).toEqual('https://support.edx.org/');
@@ -94,7 +94,7 @@ describe('LoginFailureMessage', () => {
       </IntlProvider>,
     );
 
-    const expectedMessage = 'We couldn\'t sign you in.An error has occurred. Try refreshing the page, or check your Internet connection.';
+    const expectedMessage = 'We couldn\'t sign you in.An error has occurred. Try refreshing the page, or check your internet connection.';
     expect(loginFailureMessage.find('#login-failure-alert').first().text()).toEqual(expectedMessage);
   });
 
@@ -102,7 +102,7 @@ describe('LoginFailureMessage', () => {
     props = {
       loginError: {
         errorCode: INVALID_FORM,
-        context: { email: 'Please enter your Email.', password: 'Please enter your Password.' },
+        context: { email: 'Please enter your email.', password: 'Please enter your password.' },
       },
     };
 
@@ -112,7 +112,7 @@ describe('LoginFailureMessage', () => {
       </IntlProvider>,
     );
 
-    const expectedMessage = 'We couldn\'t sign you in.Please enter your Email.Please enter your Password.';
+    const expectedMessage = 'We couldn\'t sign you in.Please enter your email.Please enter your password.';
     expect(loginFailureMessage.find('#login-failure-alert').first().text()).toEqual(expectedMessage);
   });
 

--- a/src/login/tests/LoginPage.test.jsx
+++ b/src/login/tests/LoginPage.test.jsx
@@ -147,7 +147,7 @@ describe('LoginPage', () => {
   });
 
   it('updates the error state for empty email input on form submission', () => {
-    const errorState = { email: 'Please enter your Email.', password: '' };
+    const errorState = { email: 'Please enter your email.', password: '' };
     store.dispatch = jest.fn(store.dispatch);
 
     const loginPage = (mount(reduxWrapper(<IntlLoginPage {...props} />))).find('LoginPage');
@@ -191,7 +191,7 @@ describe('LoginPage', () => {
   });
 
   it('updates the error state for invalid password', () => {
-    const errorState = { email: '', password: 'Please enter your Password.' };
+    const errorState = { email: '', password: 'Please enter your password.' };
     store.dispatch = jest.fn(store.dispatch);
 
     const loginPage = (mount(reduxWrapper(<IntlLoginPage {...props} />))).find('LoginPage');

--- a/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
+++ b/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
           onClick={[Function]}
           target="_self"
         >
-          Create an Account
+          Create an account
           .
         </a>
       </p>
@@ -28,7 +28,7 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
       <h3
         className="text-left mt-2 mb-3"
       >
-        Sign In
+        Sign in
       </h3>
       <form
         className="m-0"
@@ -196,7 +196,7 @@ exports[`LoginPage should match default section snapshot 1`] = `
           onClick={[Function]}
           target="_self"
         >
-          Create an Account
+          Create an account
           .
         </a>
       </p>
@@ -206,7 +206,7 @@ exports[`LoginPage should match default section snapshot 1`] = `
       <h3
         className="text-left mt-2 mb-3"
       >
-        Sign In
+        Sign in
       </h3>
       <form
         className="m-0"
@@ -338,7 +338,7 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
         <div
           className="alert-heading h4"
         >
-          Check Your Email
+          Check your email
         </div>
         <p>
           <span>
@@ -376,7 +376,7 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
           onClick={[Function]}
           target="_self"
         >
-          Create an Account
+          Create an account
           .
         </a>
       </p>
@@ -386,7 +386,7 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
       <h3
         className="text-left mt-2 mb-3"
       >
-        Sign In
+        Sign in
       </h3>
       <form
         className="m-0"
@@ -518,7 +518,7 @@ exports[`LoginPage should match pending button state snapshot 1`] = `
           onClick={[Function]}
           target="_self"
         >
-          Create an Account
+          Create an account
           .
         </a>
       </p>
@@ -528,7 +528,7 @@ exports[`LoginPage should match pending button state snapshot 1`] = `
       <h3
         className="text-left mt-2 mb-3"
       >
-        Sign In
+        Sign in
       </h3>
       <form
         className="m-0"
@@ -697,7 +697,7 @@ exports[`LoginPage should show error message 1`] = `
           onClick={[Function]}
           target="_self"
         >
-          Create an Account
+          Create an account
           .
         </a>
       </p>
@@ -707,7 +707,7 @@ exports[`LoginPage should show error message 1`] = `
       <h3
         className="text-left mt-2 mb-3"
       >
-        Sign In
+        Sign in
       </h3>
       <form
         className="m-0"

--- a/src/register/messages.jsx
+++ b/src/register/messages.jsx
@@ -3,7 +3,7 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 const messages = defineMessages({
   'create.account.button': {
     id: 'create.account.button',
-    defaultMessage: 'Create Account',
+    defaultMessage: 'Create account',
     description: 'Button label that appears on register page',
   },
   'already.have.an.edx.account': {
@@ -38,7 +38,7 @@ const messages = defineMessages({
   },
   'create.an.account': {
     id: 'create.an.account',
-    defaultMessage: 'Create an Account',
+    defaultMessage: 'Create an account',
     description: 'Message on button to return to register page',
   },
   'register.page.email.label': {
@@ -48,7 +48,7 @@ const messages = defineMessages({
   },
   'email.validation.message': {
     id: 'email.validation.message',
-    defaultMessage: 'Please enter your Email.',
+    defaultMessage: 'Please enter your email.',
     description: 'Validation message that appears when email address is empty',
   },
   'email.ratelimit.less.chars.validation.message': {
@@ -73,27 +73,27 @@ const messages = defineMessages({
   },
   'register.page.password.validation.message': {
     id: 'register.page.password.validation.message',
-    defaultMessage: 'Please enter your Password.',
+    defaultMessage: 'Please enter your password.',
     description: 'Validation message that appears when password is non compliant with edX requirement',
   },
   'fullname.label': {
     id: 'fullname.label',
-    defaultMessage: 'Full Name (required)',
+    defaultMessage: 'Full name (required)',
     description: 'Label that appears above fullname field',
   },
   'fullname.validation.message': {
     id: 'fullname.validation.message',
-    defaultMessage: 'Please enter your Full Name.',
+    defaultMessage: 'Please enter your full name.',
     description: 'Validation message that appears when fullname is empty',
   },
   'username.label': {
     id: 'username.label',
-    defaultMessage: 'Public Username (required)',
+    defaultMessage: 'Public username (required)',
     description: 'Label that appears above username field',
   },
   'username.validation.message': {
     id: 'username.validation.message',
-    defaultMessage: 'Please enter your Public Username.',
+    defaultMessage: 'Please enter your public username.',
     description: 'Validation message that appears when username is invalid',
   },
   'username.format.validation.message': {
@@ -133,7 +133,7 @@ const messages = defineMessages({
   },
   'registration.request.server.error': {
     id: 'registration.request.server.error',
-    defaultMessage: 'An error has occurred. Try refreshing the page, or check your Internet connection.',
+    defaultMessage: 'An error has occurred. Try refreshing the page, or check your internet connection.',
     description: 'error message on server error.',
   },
   'registration.request.failure.header': {
@@ -180,7 +180,7 @@ const messages = defineMessages({
   },
   'registration.country.label': {
     id: 'registration.country.label',
-    defaultMessage: 'Country or Region of Residence (required)',
+    defaultMessage: 'Country or region of residence (required)',
     description: 'Placeholder for the country options dropdown.',
   },
   'registration.field.gender.options.label': {
@@ -225,7 +225,7 @@ const messages = defineMessages({
   },
   'registration.field.education.levels.b': {
     id: 'registration.field.education.levels.b',
-    defaultMessage: "Bachelor's Degree",
+    defaultMessage: "Bachelor's degree",
     description: "Selected by the user if their highest level of education is a four year college or university bachelor's degree.",
   },
   'registration.field.education.levels.a': {

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -67,10 +67,10 @@ describe('RegistrationPageTests', () => {
   };
 
   const emptyFieldValidation = {
-    name: 'Please enter your Full Name.',
-    username: 'Please enter your Public Username.',
-    email: 'Please enter your Email.',
-    password: 'Please enter your Password.',
+    name: 'Please enter your full name.',
+    username: 'Please enter your public username.',
+    email: 'Please enter your email.',
+    password: 'Please enter your password.',
     country: 'Select your country or region of residence.',
   };
 
@@ -340,10 +340,10 @@ describe('RegistrationPageTests', () => {
 
   it('should display validationAlertMessages incase of invalid form submission', () => {
     const alertMessages = {
-      name: [{ user_message: 'Please enter your Full Name.' }],
-      username: [{ user_message: 'Please enter your Public Username.' }],
-      email: [{ user_message: 'Please enter your Email.' }],
-      password: [{ user_message: 'Please enter your Password.' }],
+      name: [{ user_message: 'Please enter your full name.' }],
+      username: [{ user_message: 'Please enter your public username.' }],
+      email: [{ user_message: 'Please enter your email.' }],
+      password: [{ user_message: 'Please enter your password.' }],
       country: [{ user_message: 'Select your country or region of residence.' }],
     };
     store.dispatch = jest.fn(store.dispatch);
@@ -355,10 +355,10 @@ describe('RegistrationPageTests', () => {
 
   it('should not update validationAlertMessages on blur event', () => {
     const alertMessages = {
-      name: [{ user_message: 'Please enter your Full Name.' }],
-      username: [{ user_message: 'Please enter your Public Username.' }],
-      email: [{ user_message: 'Please enter your Email.' }],
-      password: [{ user_message: 'Please enter your Password.' }],
+      name: [{ user_message: 'Please enter your full name.' }],
+      username: [{ user_message: 'Please enter your public username.' }],
+      email: [{ user_message: 'Please enter your email.' }],
+      password: [{ user_message: 'Please enter your password.' }],
       country: [{ user_message: 'Select your country or region of residence.' }],
     };
     store.dispatch = jest.fn(store.dispatch);
@@ -388,7 +388,7 @@ describe('RegistrationPageTests', () => {
 
     const registrationPage = mount(reduxWrapper(<IntlRegistrationFailure {...props} />));
     expect(registrationPage.find('div.alert-heading').length).toEqual(1);
-    const expectedMessage = 'We couldn\'t create your account.An error has occurred. Try refreshing the page, or check your Internet connection.';
+    const expectedMessage = 'We couldn\'t create your account.An error has occurred. Try refreshing the page, or check your internet connection.';
     expect(registrationPage.find('div.alert').first().text()).toEqual(expectedMessage);
   });
 

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Full Name (required)"
+            placeholder="Full name (required)"
             required={true}
             type="text"
             value=""
@@ -65,7 +65,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Public Username (required)"
+            placeholder="Public username (required)"
             required={true}
             type="text"
             value=""
@@ -125,14 +125,14 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Country or Region of Residence (required)"
+            placeholder="Country or region of residence (required)"
             required={true}
             value=""
           >
             <option
               value=""
             >
-              Country or Region of Residence (required)
+              Country or region of residence (required)
             </option>
             <option
               value="AF"
@@ -1477,7 +1477,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           <span
             className="d-flex align-items-center justify-content-center"
           >
-            Create Account
+            Create account
           </span>
         </button>
         <div
@@ -1570,7 +1570,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Full Name (required)"
+            placeholder="Full name (required)"
             required={true}
             type="text"
             value=""
@@ -1590,7 +1590,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Public Username (required)"
+            placeholder="Public username (required)"
             required={true}
             type="text"
             value=""
@@ -1650,14 +1650,14 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Country or Region of Residence (required)"
+            placeholder="Country or region of residence (required)"
             required={true}
             value=""
           >
             <option
               value=""
             >
-              Country or Region of Residence (required)
+              Country or region of residence (required)
             </option>
             <option
               value="AF"
@@ -3002,7 +3002,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           <span
             className="d-flex align-items-center justify-content-center"
           >
-            Create Account
+            Create account
           </span>
         </button>
       </form>
@@ -3056,7 +3056,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Full Name (required)"
+            placeholder="Full name (required)"
             required={true}
             type="text"
             value=""
@@ -3076,7 +3076,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Public Username (required)"
+            placeholder="Public username (required)"
             required={true}
             type="text"
             value=""
@@ -3136,14 +3136,14 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
             onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            placeholder="Country or Region of Residence (required)"
+            placeholder="Country or region of residence (required)"
             required={true}
             value=""
           >
             <option
               value=""
             >
-              Country or Region of Residence (required)
+              Country or region of residence (required)
             </option>
             <option
               value="AF"
@@ -4509,7 +4509,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
                 />
               </svg>
             </span>
-            Create Account
+            Create account
           </span>
         </button>
       </form>

--- a/src/reset-password/messages.js
+++ b/src/reset-password/messages.js
@@ -18,12 +18,12 @@ const messages = defineMessages({
   },
   'reset.password.page.new.field.label': {
     id: 'forgot.password.page.new.field.label',
-    defaultMessage: 'New Password',
+    defaultMessage: 'New password',
     description: 'New password field label for the reset password page.',
   },
   'reset.password.page.confirm.field.label': {
     id: 'forgot.password.page.confirm.field.label',
-    defaultMessage: 'Confirm Password',
+    defaultMessage: 'Confirm password',
     description: 'Confirm password field label for the reset password page.',
   },
   'reset.password.page.submit.button': {
@@ -33,27 +33,27 @@ const messages = defineMessages({
   },
   'reset.password.request.success.header.message': {
     id: 'reset.password.request.success.header.message',
-    defaultMessage: 'Password Reset Complete.',
+    defaultMessage: 'Password reset complete.',
     description: 'header message when reset is successful.',
   },
   'forgot.password.confirmation.sign.in.link': {
     id: 'forgot.password.confirmation.sign.in.link',
-    defaultMessage: 'sign-in',
+    defaultMessage: 'sign in',
     description: 'link text used in message to refer to sign in page',
   },
   'reset.password.request.forgot.password.text': {
     id: 'reset.password.request.forgot.password.text',
-    defaultMessage: 'Forgot Password',
+    defaultMessage: 'Forgot password',
     description: 'Forgot password text',
   },
   'reset.password.request.invalid.token.header': {
     id: 'reset.password.request.invalid.token.header',
-    defaultMessage: 'Invalid Password Reset Link',
+    defaultMessage: 'Invalid password reset link',
     description: 'Invalid password reset link help text heading',
   },
   'reset.password.empty.new.password.field.error': {
     id: 'reset.password.empty.new.password.field.error',
-    defaultMessage: 'Please enter your New Password.',
+    defaultMessage: 'Please enter your new password.',
     description: 'Error message that appears when user tries to submit form with empty New Password field',
   },
   'forgot.password.empty.new.password.error.heading': {

--- a/src/reset-password/tests/ResetPasswordPage.test.jsx
+++ b/src/reset-password/tests/ResetPasswordPage.test.jsx
@@ -22,7 +22,7 @@ describe('ResetPasswordPage', () => {
   let props = {};
   let store = {};
 
-  const emptyFieldError = 'Please enter your New Password.';
+  const emptyFieldError = 'Please enter your new password.';
   const validationMessage = 'This password is too short. It must contain at least 8 characters. This password must contain at least 1 number.';
 
   const reduxWrapper = children => (

--- a/src/reset-password/tests/__snapshots__/ResetPasswordPage.test.jsx.snap
+++ b/src/reset-password/tests/__snapshots__/ResetPasswordPage.test.jsx.snap
@@ -34,7 +34,7 @@ exports[`ResetPasswordPage should match invalid token message section snapshot 1
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          placeholder="New Password"
+          placeholder="New password"
           required={true}
           type="password"
           value=""
@@ -54,7 +54,7 @@ exports[`ResetPasswordPage should match invalid token message section snapshot 1
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          placeholder="Confirm Password"
+          placeholder="Confirm password"
           required={true}
           type="password"
           value=""
@@ -121,7 +121,7 @@ exports[`ResetPasswordPage should match pending reset message section snapshot 1
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          placeholder="New Password"
+          placeholder="New password"
           required={true}
           type="password"
           value=""
@@ -141,7 +141,7 @@ exports[`ResetPasswordPage should match pending reset message section snapshot 1
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          placeholder="Confirm Password"
+          placeholder="Confirm password"
           required={true}
           type="password"
           value=""
@@ -229,7 +229,7 @@ exports[`ResetPasswordPage should match reset password default section snapshot 
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          placeholder="New Password"
+          placeholder="New password"
           required={true}
           type="password"
           value=""
@@ -249,7 +249,7 @@ exports[`ResetPasswordPage should match reset password default section snapshot 
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          placeholder="Confirm Password"
+          placeholder="Confirm password"
           required={true}
           type="password"
           value=""
@@ -299,7 +299,7 @@ exports[`ResetPasswordPage should match successful reset message section snapsho
         <div
           className="alert-heading h4"
         >
-          Password Reset Complete.
+          Password reset complete.
         </div>
         <span>
           Your password has been reset. 
@@ -354,7 +354,7 @@ exports[`ResetPasswordPage show spinner component during token validation 1`] = 
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          placeholder="New Password"
+          placeholder="New password"
           required={true}
           type="password"
           value=""
@@ -374,7 +374,7 @@ exports[`ResetPasswordPage show spinner component during token validation 1`] = 
           onChange={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          placeholder="Confirm Password"
+          placeholder="Confirm password"
           required={true}
           type="password"
           value=""


### PR DESCRIPTION
Register page:
- [x] Update placeholders on the register page to use sentence case.
- [x] Update button test to use sentence case. 

Login page:
- [x] Update title to use sentence case.
- [x] update "Create an Account" hyperlink to use sentence case. 

Password Assistance
- [x] update hyperlink "Other sign-in issues" and replace hyphen with space.
- [x]  update "Check your Email" title to use sentence case for when user has requested a password recovery. 

Reset Password page:
- [x] Update placeholders on reset password page to use sentence case.

[VAN-393](https://openedx.atlassian.net/browse/VAN-393)