### PR TITLE
VAN-397: Realign social auth providers

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -46,13 +46,12 @@ $apple-focus-black: $apple-black;
   justify-content: flex-start;
   align-items: center;
 
-  margin: 5px;
+  margin-bottom: 1rem;
   font-size: 14px;
 
   background-color: $white;
   border: 1px solid $font-blue;
-  border-radius: 2px;
-  width: 160px;
+  width: 242px;
   height: 36px;
   color: $font-blue;
 
@@ -80,7 +79,9 @@ $apple-focus-black: $apple-black;
 .tpa-container {
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: flex-start;
+
+  margin: 0 !important;
 }
 
 .font-container {

--- a/src/common-components/SocialAuthProviders.jsx
+++ b/src/common-components/SocialAuthProviders.jsx
@@ -17,12 +17,12 @@ function SocialAuthProviders(props) {
     window.location.href = getConfig().LMS_BASE_URL + url;
   }
 
-  const socialAuth = socialAuthProviders.map((provider) => (
+  const socialAuth = socialAuthProviders.map((provider, index) => (
     <button
       id={provider.id}
       key={provider.id}
       type="button"
-      className={`btn-social btn-${provider.id}`}
+      className={`btn-social btn-${provider.id} ${index % 2 === 0 ? 'mr-3' : ''}`}
       data-provider-url={referrer === LOGIN_PAGE ? provider.loginUrl : provider.registerUrl}
       onClick={handleSubmit}
     >

--- a/src/common-components/tests/SocialAuthProviders.test.jsx
+++ b/src/common-components/tests/SocialAuthProviders.test.jsx
@@ -18,8 +18,16 @@ describe('SocialAuthProviders', () => {
     loginUrl: '/auth/login/apple-id/?auth_entry=login&next=/dashboard',
   };
 
+  const facebookProvider = {
+    id: 'oa2-facebook',
+    name: 'Facebook',
+    iconClass: null,
+    iconImage: 'https://edx.devstack.lms/facebook-logo.png',
+    loginUrl: '/auth/login/facebook/?auth_entry=login&next=/dashboard',
+  };
+
   it('should match social auth provider with iconImage snapshot', () => {
-    props = { socialAuthProviders: [appleProvider] };
+    props = { socialAuthProviders: [appleProvider, facebookProvider] };
 
     const tree = renderer.create(
       <IntlProvider locale="en">

--- a/src/common-components/tests/__snapshots__/SocialAuthProviders.test.jsx.snap
+++ b/src/common-components/tests/__snapshots__/SocialAuthProviders.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SocialAuthProviders should match social auth provider with default icon snapshot 1`] = `
 <button
-  className="btn-social btn-oa2-apple-id"
+  className="btn-social btn-oa2-apple-id mr-3"
   data-provider-url="/auth/login/apple-id/?auth_entry=login&next=/dashboard"
   id="oa2-apple-id"
   onClick={[Function]}
@@ -41,7 +41,7 @@ exports[`SocialAuthProviders should match social auth provider with default icon
 
 exports[`SocialAuthProviders should match social auth provider with iconClass snapshot 1`] = `
 <button
-  className="btn-social btn-oa2-apple-id"
+  className="btn-social btn-oa2-apple-id mr-3"
   data-provider-url="/auth/login/apple-id/?auth_entry=login&next=/dashboard"
   id="oa2-apple-id"
   onClick={[Function]}
@@ -79,28 +79,54 @@ exports[`SocialAuthProviders should match social auth provider with iconClass sn
 `;
 
 exports[`SocialAuthProviders should match social auth provider with iconImage snapshot 1`] = `
-<button
-  className="btn-social btn-oa2-apple-id"
-  data-provider-url="/auth/login/apple-id/?auth_entry=login&next=/dashboard"
-  id="oa2-apple-id"
-  onClick={[Function]}
-  type="button"
->
-  <div
-    aria-hidden="true"
-    className="mx-auto"
+Array [
+  <button
+    className="btn-social btn-oa2-apple-id mr-3"
+    data-provider-url="/auth/login/apple-id/?auth_entry=login&next=/dashboard"
+    id="oa2-apple-id"
+    onClick={[Function]}
+    type="button"
   >
-    <img
-      alt="icon Apple"
-      className="icon-image"
-      src="https://edx.devstack.lms/logo.png"
-    />
-    <span
+    <div
       aria-hidden="true"
-      className="pl-2"
+      className="mx-auto"
     >
-      Apple
-    </span>
-  </div>
-</button>
+      <img
+        alt="icon Apple"
+        className="icon-image"
+        src="https://edx.devstack.lms/logo.png"
+      />
+      <span
+        aria-hidden="true"
+        className="pl-2"
+      >
+        Apple
+      </span>
+    </div>
+  </button>,
+  <button
+    className="btn-social btn-oa2-facebook "
+    data-provider-url="/auth/login/facebook/?auth_entry=login&next=/dashboard"
+    id="oa2-facebook"
+    onClick={[Function]}
+    type="button"
+  >
+    <div
+      aria-hidden="true"
+      className="mx-auto"
+    >
+      <img
+        alt="icon Facebook"
+        className="icon-image"
+        src="https://edx.devstack.lms/facebook-logo.png"
+      />
+      <span
+        aria-hidden="true"
+        className="pl-2"
+      >
+        Facebook
+      </span>
+    </div>
+  </button>,
+]
 `;

--- a/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
+++ b/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
@@ -149,7 +149,7 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
         className="row tpa-container"
       >
         <button
-          className="btn-social btn-oa2-apple-id"
+          className="btn-social btn-oa2-apple-id mr-3"
           data-provider-url="/auth/login/apple-id/?auth_entry=login&next=/dashboard"
           id="oa2-apple-id"
           onClick={[Function]}

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -1496,7 +1496,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           className="row tpa-container"
         >
           <button
-            className="btn-social btn-oa2-apple-id"
+            className="btn-social btn-oa2-apple-id mr-3"
             id="oa2-apple-id"
             onClick={[Function]}
             type="button"


### PR DESCRIPTION
### Notes: 
Keep the social auth buttons left aligned and two in each row.

Ticket: https://openedx.atlassian.net/browse/VAN-397

-----

|Login|Register|
|------|-------|
|<img width="558" alt="Screenshot 2021-02-23 at 4 20 05 PM" src="https://user-images.githubusercontent.com/40633976/108837019-6b24ab00-75f3-11eb-96e9-f597225995bf.png"> | <img width="558" alt="Screenshot 2021-02-23 at 4 20 16 PM" src="https://user-images.githubusercontent.com/40633976/108837036-6f50c880-75f3-11eb-9ecc-2b1a482bacb0.png">|

