### PR TITLE
Fix responsiveness issue of sso buttons

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -257,7 +257,7 @@ $apple-focus-black: $apple-black;
 }
 
 a span {
-  font-size: 0;
+  @extend .sr-only;
 }
 
 .mw-420 {
@@ -294,6 +294,17 @@ a span {
 @media (min-width: 1024px) {
   .mw-500 {
     width: 500px;
+  }
+}
+
+@media (max-width: 600px) {
+  .btn-social {
+    width: 47%;
+    margin-bottom: 0.75rem;
+  }
+
+  .tpa-container {
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
Fixed two issues in this PR:
- Made SSO buttons responsive. The reason for justifying content to centre for screen size <= 600 is because if I keep it left align there is a minor unwanted gap on the right side only. Keeping it centre aligned divides that gap and is not noticeable. 
- The previous fix for removing unwanted space from `Privacy Policy` hyperlink was not working on stage. I have added the sr-only class to the  `<span />` inside hyperlink. The span is for screen readers only and hence `.sr-only` class seems fitting to add here.

----

**The highlighted blue area represents the form size:**
<img width="412" alt="Screenshot 2021-02-25 at 10 39 15 AM" src="https://user-images.githubusercontent.com/40633976/109108628-b9ea5600-7755-11eb-8ec5-190786c7e479.png">
