### PR TITLE
Fix: All span inside anchor tag have sr-only class

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -256,7 +256,7 @@ $apple-focus-black: $apple-black;
   margin-left: -5px;
 }
 
-a span {
+#honor-code a span {
   @extend .sr-only;
 }
 


### PR DESCRIPTION
Due to a recent change, password reset alert banner stopped showing the hyperlink to sign back. It was due to the generic css that was added in the styles. I have restricted it to honor code only 