### PR TITLE
Add es language option.

### DIFF
--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -15,6 +15,7 @@ import ukMessages from './messages/uk.json';
 
 const messages = {
   ar: arMessages,
+  es: es419Messages, // Prospectus uses es language code for spanish, added `es` option and pointed to es-419 strings.
   'es-419': es419Messages,
   fr: frMessages,
   'zh-cn': zhcnMessages,


### PR DESCRIPTION
Prospectus set `es` code for Spanish instead of es-419. Added `es` option and pointed to `es-419` strings so that we don't need to maintain two separate instances of strings for the same language in Transifex.