### PR TITLE
Enable Hotjar for Authn MFE

### DIFF
--- a/src/common-components/ConfirmationAlert.jsx
+++ b/src/common-components/ConfirmationAlert.jsx
@@ -19,7 +19,7 @@ const ConfirmationAlert = (props) => {
           defaultMessage="You entered {strongEmail}. If this email address is associated with your
           edX account, we will send a message with password recovery instructions to this email address."
           description="Forgot password confirmation message"
-          values={{ strongEmail: <strong>{email}</strong> }}
+          values={{ strongEmail: <strong className="data-hj-suppress">{email}</strong> }}
         />
       </p>
       <p>{intl.formatMessage(messages['forgot.password.confirmation.info'])}</p>

--- a/src/login/LoginFailure.jsx
+++ b/src/login/LoginFailure.jsx
@@ -63,7 +63,7 @@ const LoginFailureMessage = (props) => {
             check your spam folders or {supportLink}."
             values={{
               lineBreak: <br />,
-              email: <strong>{props.loginError.email}</strong>,
+              email: <strong className="data-hj-suppress">{props.loginError.email}</strong>,
               supportLink,
             }}
           />

--- a/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
+++ b/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
@@ -363,7 +363,9 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
         <p>
           <span>
             You entered 
-            <strong>
+            <strong
+              className="data-hj-suppress"
+            >
               test@example.com
             </strong>
             . If this email address is associated with your edX account, we will send a message with password recovery instructions to this email address.

--- a/src/register/OptionalFields.jsx
+++ b/src/register/OptionalFields.jsx
@@ -35,7 +35,7 @@ const OptionalFields = (props) => {
         type="select"
         key="gender"
         value={values.gender}
-        className="mb-20 opt-inline-field"
+        className="mb-20 opt-inline-field data-hj-suppress"
         onChange={(e) => onChangeHandler('gender', e.target.value)}
         selectOptions={getOptions().genderOptions}
       />
@@ -46,7 +46,7 @@ const OptionalFields = (props) => {
         type="select"
         key="yearOfBirth"
         value={values.yearOfBirth}
-        className="mb-20 opt-inline-field opt-year-field"
+        className="mb-20 opt-inline-field opt-year-field data-hj-suppress"
         onChange={(e) => onChangeHandler('yearOfBirth', e.target.value)}
         selectOptions={getOptions().yearOfBirthOptions}
       />
@@ -57,7 +57,7 @@ const OptionalFields = (props) => {
         type="select"
         key="levelOfEducation"
         value={values.levelOfEducation}
-        className="mb-20"
+        className="mb-20 data-hj-suppress"
         onChange={(e) => onChangeHandler('levelOfEducation', e.target.value)}
         selectOptions={getOptions().educationLevelOptions}
       />

--- a/src/register/RegistrationFailure.jsx
+++ b/src/register/RegistrationFailure.jsx
@@ -31,9 +31,10 @@ const RegistrationFailureMessage = (props) => {
      default:
         Object.keys(errorMessage).forEach((key) => {
           const errors = errorMessage[key];
+          const suppressionClass = ['email', 'username'].includes(key) ? 'data-hj-suppress' : '';
           const errorList = errors.map((error) => (
             (error.user_message) ? (
-              <li key={error} className="text-left">
+              <li key={error} className={`text-left ${suppressionClass}`}>
                 {error.user_message}
               </li>
             ) : null
@@ -45,14 +46,8 @@ const RegistrationFailureMessage = (props) => {
   return (
     !userErrors.length ? null : (
       <Alert id="validation-errors" variant="danger">
-        <Alert.Heading>
-          {props.intl.formatMessage(messages['registration.request.failure.header'])}
-        </Alert.Heading>
-
-        <ul>
-          {userErrors}
-        </ul>
-
+        <Alert.Heading>{props.intl.formatMessage(messages['registration.request.failure.header'])}</Alert.Heading>
+        <ul>{userErrors}</ul>
       </Alert>
     )
   );

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -483,6 +483,7 @@ class RegistrationPage extends React.Component {
                   for="username"
                   name="username"
                   type="text"
+                  className="data-hj-suppress"
                   invalid={this.state.errors.username !== ''}
                   invalidMessage={this.state.errors.username}
                   value={this.state.username}
@@ -495,6 +496,7 @@ class RegistrationPage extends React.Component {
                   for="email"
                   name="email"
                   type="text"
+                  className="data-hj-suppress"
                   invalid={this.state.errors.email !== ''}
                   invalidMessage={this.state.errors.email}
                   value={this.state.email}
@@ -524,7 +526,7 @@ class RegistrationPage extends React.Component {
                   key="country"
                   invalid={this.state.errors.country !== ''}
                   invalidMessage={intl.formatMessage(messages['country.validation.message'])}
-                  className="mb-0"
+                  className="mb-0 data-hj-suppress"
                   value={this.state.country}
                   onBlur={(e) => this.handleOnBlur(e)}
                   onChange={(e) => this.handleOnChange(e)}

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           <span />
         </div>
         <div
-          className="form-group"
+          className="form-group data-hj-suppress"
         >
           <label
             className="pt-10 focus-out form-label"
@@ -81,7 +81,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           <span />
         </div>
         <div
-          className="form-group"
+          className="form-group data-hj-suppress"
         >
           <label
             className="pt-10 focus-out form-label"
@@ -129,7 +129,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           <span />
         </div>
         <div
-          className="form-group mb-0"
+          className="form-group mb-0 data-hj-suppress"
         >
           <label
             className="sr-only form-label"
@@ -1608,7 +1608,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           <span />
         </div>
         <div
-          className="form-group"
+          className="form-group data-hj-suppress"
         >
           <label
             className="pt-10 focus-out form-label"
@@ -1632,7 +1632,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           <span />
         </div>
         <div
-          className="form-group"
+          className="form-group data-hj-suppress"
         >
           <label
             className="pt-10 focus-out form-label"
@@ -1680,7 +1680,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           <span />
         </div>
         <div
-          className="form-group mb-0"
+          className="form-group mb-0 data-hj-suppress"
         >
           <label
             className="sr-only form-label"
@@ -3120,7 +3120,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           <span />
         </div>
         <div
-          className="form-group"
+          className="form-group data-hj-suppress"
         >
           <label
             className="pt-10 focus-out form-label"
@@ -3144,7 +3144,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           <span />
         </div>
         <div
-          className="form-group"
+          className="form-group data-hj-suppress"
         >
           <label
             className="pt-10 focus-out form-label"
@@ -3192,7 +3192,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           <span />
         </div>
         <div
-          className="form-group mb-0"
+          className="form-group mb-0 data-hj-suppress"
         >
           <label
             className="sr-only form-label"


### PR DESCRIPTION
Suppressed PII from logistration pages to enable Hotjar. Data entered in forms is by default suppressed by Hotjar. PII Suppression is done by adding `data-hj-suppress` as an attribute or class. From Hotjar's documentation:
```html
<p class="data-hj-suppress">Suppress me.</p>
<p>Do not suppress me.</p>
```

----

#### Changes include:
- [x] Suppress data entered in form (Hotjar already does this by default. No data entered in any input field is captured by Hotjar)
- [x] Suppress dropdown values selected by user.
- [x] If error messages include PII, suppress it using the `data-hj-suppress` class

----

Ticket: [VAN-290](https://openedx.atlassian.net/browse/VAN-290)