### PR TITLE
Send social_auth_provider param upon registration

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -162,7 +162,9 @@ class RegistrationPage extends React.Component {
       honor_code: true,
     };
 
-    if (!this.props.thirdPartyAuthContext.currentProvider) {
+    if (this.props.thirdPartyAuthContext.currentProvider) {
+      payload.social_auth_provider = this.props.thirdPartyAuthContext.currentProvider;
+    } else {
       payload.password = this.state.password;
     }
 


### PR DESCRIPTION
On FE if third party auth session has expired and user tried to register, an error message is shown. This is however not happening on MFE because we are not sending `social_auth_provider` param in the registration request which breaks the logic at the backend and incorrect message is shown to the user.

#### Solution:
If current provider is present, then send the `social_auth_provider` in the registration payload. If there is no running pipeline at the backend at the time of submission, correct error message is shown on MFE:
|Before|After|
|----|-----|
|<img width="552" alt="Screenshot 2021-03-09 at 5 33 50 PM" src="https://user-images.githubusercontent.com/40633976/110471180-a2b84a80-80fd-11eb-84e2-fa040f0d55bc.png">|<img width="552" alt="Screenshot 2021-03-09 at 5 02 57 PM" src="https://user-images.githubusercontent.com/40633976/110470950-50772980-80fd-11eb-8e4b-1bfdd78f8552.png">|


[VAN-55](https://openedx.atlassian.net/browse/VAN-55)