### PR TITLE
Add 3:1 contrast to all text field.

### DIFF
--- a/src/common-components/AuthnValidationFormGroup.jsx
+++ b/src/common-components/AuthnValidationFormGroup.jsx
@@ -61,6 +61,7 @@ const AuthnCustomValidationFormGroup = (props) => {
     id: props.for,
     type: props.type,
     value: props.value,
+    className: props.inputFieldStyle,
   };
   inputProps.onChange = (e) => onChangeHandler(e, onChange);
   inputProps.onClick = (e) => onClickHandler(e, onClick);
@@ -69,7 +70,7 @@ const AuthnCustomValidationFormGroup = (props) => {
 
   if (props.type === 'select') {
     inputProps.options = props.selectOptions;
-    inputProps.className = props.value === '' ? 'text-muted' : null;
+    inputProps.className = props.value === '' ? 'text-muted border-gray-600' : null;
   }
   if (props.type === 'checkbox') {
     inputProps.checked = props.isChecked;
@@ -112,6 +113,7 @@ AuthnCustomValidationFormGroup.defaultProps = {
   value: '',
   invalid: false,
   invalidMessage: '',
+  inputFieldStyle: '',
   helpText: '',
   className: '',
   onClick: null,
@@ -135,6 +137,7 @@ AuthnCustomValidationFormGroup.propTypes = {
   invalidMessage: PropTypes.string,
   helpText: PropTypes.string,
   className: PropTypes.string,
+  inputFieldStyle: PropTypes.string,
   isChecked: PropTypes.bool,
   optionalFieldCheckbox: PropTypes.bool,
   onClick: PropTypes.func,

--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -116,6 +116,7 @@ const ForgotPasswordPage = (props) => {
                   onChange={e => setFieldValue('email', e.target.value)}
                   helpText={intl.formatMessage(messages['forgot.password.email.help.text'], { platformName })}
                   className="mb-0 w-100"
+                  inputFieldStyle="border-gray-600"
                 />
                 <LoginHelpLinks page="forgot-password" />
                 <StatefulButton

--- a/src/forgot-password/tests/__snapshots__/ForgotPasswordPage.test.jsx.snap
+++ b/src/forgot-password/tests/__snapshots__/ForgotPasswordPage.test.jsx.snap
@@ -31,7 +31,7 @@ exports[`ForgotPasswordPage should match default section snapshot 1`] = `
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="forgot-password-input"
           name="email"
           onBlur={[Function]}
@@ -96,9 +96,7 @@ exports[`ForgotPasswordPage should match default section snapshot 1`] = `
         <span
           className="d-flex align-items-center justify-content-center"
         >
-          <span>
-            Recover my password
-          </span>
+          Recover my password
         </span>
       </button>
     </form>
@@ -152,7 +150,7 @@ exports[`ForgotPasswordPage should match forbidden section snapshot 1`] = `
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="forgot-password-input"
           name="email"
           onBlur={[Function]}
@@ -217,9 +215,7 @@ exports[`ForgotPasswordPage should match forbidden section snapshot 1`] = `
         <span
           className="d-flex align-items-center justify-content-center"
         >
-          <span>
-            Recover my password
-          </span>
+          Recover my password
         </span>
       </button>
     </form>
@@ -258,7 +254,7 @@ exports[`ForgotPasswordPage should match pending section snapshot 1`] = `
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="forgot-password-input"
           name="email"
           onBlur={[Function]}
@@ -344,9 +340,7 @@ exports[`ForgotPasswordPage should match pending section snapshot 1`] = `
               />
             </svg>
           </span>
-          <span>
-            Recover my password
-          </span>
+          Recover my password
         </span>
       </button>
     </form>

--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -222,6 +222,7 @@ class LoginPage extends React.Component {
                   value={email}
                   helpText={intl.formatMessage(messages['email.help.message'])}
                   onChange={(e) => this.setState({ email: e.target.value, isSubmitted: false })}
+                  inputFieldStyle="border-gray-600"
                 />
                 <AuthnValidationFormGroup
                   label={intl.formatMessage(messages['password.label'])}
@@ -232,6 +233,7 @@ class LoginPage extends React.Component {
                   invalidMessage={errors.password}
                   value={password}
                   onChange={(e) => this.setState({ password: e.target.value, isSubmitted: false })}
+                  inputFieldStyle="border-gray-600"
                 />
                 <LoginHelpLinks page={LOGIN_PAGE} />
                 <Hyperlink className="field-link mt-0 mb-3 small" destination={this.getEnterPriseLoginURL()}>

--- a/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
+++ b/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
@@ -44,7 +44,7 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="email"
             name="email"
             onBlur={[Function]}
@@ -68,7 +68,7 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="password"
             name="password"
             onBlur={[Function]}
@@ -141,9 +141,7 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
           <span
             className="d-flex align-items-center justify-content-center"
           >
-            <span>
-              Sign in
-            </span>
+            Sign in
           </span>
         </button>
       </form>
@@ -232,7 +230,7 @@ exports[`LoginPage should match default section snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="email"
             name="email"
             onBlur={[Function]}
@@ -256,7 +254,7 @@ exports[`LoginPage should match default section snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="password"
             name="password"
             onBlur={[Function]}
@@ -329,9 +327,7 @@ exports[`LoginPage should match default section snapshot 1`] = `
           <span
             className="d-flex align-items-center justify-content-center"
           >
-            <span>
-              Sign in
-            </span>
+            Sign in
           </span>
         </button>
       </form>
@@ -424,7 +420,7 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="email"
             name="email"
             onBlur={[Function]}
@@ -448,7 +444,7 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="password"
             name="password"
             onBlur={[Function]}
@@ -521,9 +517,7 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
           <span
             className="d-flex align-items-center justify-content-center"
           >
-            <span>
-              Sign in
-            </span>
+            Sign in
           </span>
         </button>
       </form>
@@ -576,7 +570,7 @@ exports[`LoginPage should match pending button state snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="email"
             name="email"
             onBlur={[Function]}
@@ -600,7 +594,7 @@ exports[`LoginPage should match pending button state snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="password"
             name="password"
             onBlur={[Function]}
@@ -694,9 +688,7 @@ exports[`LoginPage should match pending button state snapshot 1`] = `
                 />
               </svg>
             </span>
-            <span>
-              Sign in
-            </span>
+            Sign in
           </span>
         </button>
       </form>
@@ -765,7 +757,7 @@ exports[`LoginPage should show error message 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="email"
             name="email"
             onBlur={[Function]}
@@ -789,7 +781,7 @@ exports[`LoginPage should show error message 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="password"
             name="password"
             onBlur={[Function]}
@@ -862,9 +854,7 @@ exports[`LoginPage should show error message 1`] = `
           <span
             className="d-flex align-items-center justify-content-center"
           >
-            <span>
-              Sign in
-            </span>
+            Sign in
           </span>
         </button>
       </form>

--- a/src/register/OptionalFields.jsx
+++ b/src/register/OptionalFields.jsx
@@ -70,6 +70,7 @@ const OptionalFields = (props) => {
         value={values.goals}
         className="mb-20"
         onChange={(e) => onChangeHandler('goals', e.target.value)}
+        inputFieldStyle="border-gray-600"
       />
     </>
   );

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -478,6 +478,7 @@ class RegistrationPage extends React.Component {
                   onBlur={(e) => this.handleOnBlur(e)}
                   onChange={(e) => this.handleOnChange(e)}
                   helpText={intl.formatMessage(messages['helptext.name'])}
+                  inputFieldStyle="border-gray-600"
                 />
                 <AuthnValidationFormGroup
                   label={intl.formatMessage(messages['username.label'])}
@@ -491,6 +492,7 @@ class RegistrationPage extends React.Component {
                   onBlur={(e) => this.handleOnBlur(e)}
                   onChange={(e) => this.handleOnChange(e)}
                   helpText={intl.formatMessage(messages['helptext.username'])}
+                  inputFieldStyle="border-gray-600"
                 />
                 <AuthnValidationFormGroup
                   label={intl.formatMessage(messages['register.page.email.label'])}
@@ -504,6 +506,7 @@ class RegistrationPage extends React.Component {
                   onBlur={(e) => this.handleOnBlur(e)}
                   onChange={(e) => this.handleOnChange(e)}
                   helpText={intl.formatMessage(messages['helptext.email'])}
+                  inputFieldStyle="border-gray-600"
                 />
                 {!currentProvider && (
                   <AuthnValidationFormGroup
@@ -517,6 +520,7 @@ class RegistrationPage extends React.Component {
                     onBlur={(e) => this.handleOnBlur(e)}
                     onChange={(e) => this.handleOnChange(e)}
                     helpText={intl.formatMessage(messages['helptext.password'])}
+                    inputFieldStyle="border-gray-600"
                   />
                 )}
                 <AuthnValidationFormGroup
@@ -532,6 +536,7 @@ class RegistrationPage extends React.Component {
                   onBlur={(e) => this.handleOnBlur(e)}
                   onChange={(e) => this.handleOnChange(e)}
                   selectOptions={this.getCountryOptions()}
+                  inputFieldStyle="border-gray-600"
                 />
                 <div id="honor-code" className="pt-10 small">
                   <FormattedMessage

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -43,7 +43,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="name"
             name="name"
             onBlur={[Function]}
@@ -67,7 +67,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="username"
             name="username"
             onBlur={[Function]}
@@ -91,7 +91,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="email"
             name="email"
             onBlur={[Function]}
@@ -115,7 +115,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="password"
             name="password"
             onBlur={[Function]}
@@ -139,7 +139,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           </label>
           <select
             aria-describedby=""
-            className="form-control text-muted"
+            className="form-control text-muted border-gray-600"
             id="country"
             name="country"
             onBlur={[Function]}
@@ -1501,9 +1501,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           <span
             className="d-flex align-items-center justify-content-center"
           >
-            <span>
-              Create account
-            </span>
+            Create account
           </span>
         </button>
         <div
@@ -1594,7 +1592,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="name"
             name="name"
             onBlur={[Function]}
@@ -1618,7 +1616,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="username"
             name="username"
             onBlur={[Function]}
@@ -1642,7 +1640,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="email"
             name="email"
             onBlur={[Function]}
@@ -1666,7 +1664,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="password"
             name="password"
             onBlur={[Function]}
@@ -1690,7 +1688,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           </label>
           <select
             aria-describedby=""
-            className="form-control text-muted"
+            className="form-control text-muted border-gray-600"
             id="country"
             name="country"
             onBlur={[Function]}
@@ -3052,9 +3050,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           <span
             className="d-flex align-items-center justify-content-center"
           >
-            <span>
-              Create account
-            </span>
+            Create account
           </span>
         </button>
       </form>
@@ -3106,7 +3102,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="name"
             name="name"
             onBlur={[Function]}
@@ -3130,7 +3126,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="username"
             name="username"
             onBlur={[Function]}
@@ -3154,7 +3150,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="email"
             name="email"
             onBlur={[Function]}
@@ -3178,7 +3174,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           </label>
           <input
             aria-describedby=""
-            className="form-control"
+            className="form-control border-gray-600"
             id="password"
             name="password"
             onBlur={[Function]}
@@ -3202,7 +3198,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           </label>
           <select
             aria-describedby=""
-            className="form-control text-muted"
+            className="form-control text-muted border-gray-600"
             id="country"
             name="country"
             onBlur={[Function]}
@@ -4585,9 +4581,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
                 />
               </svg>
             </span>
-            <span>
-              Create account
-            </span>
+            Create account
           </span>
         </button>
       </form>

--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -158,6 +158,7 @@ const ResetPasswordPage = (props) => {
                 onChange={e => handleNewPasswordChange(e)}
                 onBlur={e => handleNewPasswordOnBlur(e)}
                 className="w-100"
+                inputFieldStyle="border-gray-600"
               />
               <AuthnValidationFormGroup
                 label={intl.formatMessage(messages['reset.password.page.confirm.field.label'])}
@@ -169,6 +170,7 @@ const ResetPasswordPage = (props) => {
                 value={confirmPasswordInput}
                 onChange={e => handleConfirmPasswordChange(e)}
                 className="w-100"
+                inputFieldStyle="border-gray-600"
               />
               <StatefulButton
                 type="submit"

--- a/src/reset-password/tests/__snapshots__/ResetPasswordPage.test.jsx.snap
+++ b/src/reset-password/tests/__snapshots__/ResetPasswordPage.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`ResetPasswordPage should match invalid token message section snapshot 1
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="reset-password-input"
           name="new-password1"
           onBlur={[Function]}
@@ -56,7 +56,7 @@ exports[`ResetPasswordPage should match invalid token message section snapshot 1
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="confirm-password-input"
           name="new-password2"
           onBlur={[Function]}
@@ -87,9 +87,7 @@ exports[`ResetPasswordPage should match invalid token message section snapshot 1
         <span
           className="d-flex align-items-center justify-content-center"
         >
-          <span>
-            Reset my password
-          </span>
+          Reset my password
         </span>
       </button>
     </form>
@@ -129,7 +127,7 @@ exports[`ResetPasswordPage should match pending reset message section snapshot 1
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="reset-password-input"
           name="new-password1"
           onBlur={[Function]}
@@ -153,7 +151,7 @@ exports[`ResetPasswordPage should match pending reset message section snapshot 1
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="confirm-password-input"
           name="new-password2"
           onBlur={[Function]}
@@ -205,9 +203,7 @@ exports[`ResetPasswordPage should match pending reset message section snapshot 1
               />
             </svg>
           </span>
-          <span>
-            Reset my password
-          </span>
+          Reset my password
         </span>
       </button>
     </form>
@@ -247,7 +243,7 @@ exports[`ResetPasswordPage should match reset password default section snapshot 
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="reset-password-input"
           name="new-password1"
           onBlur={[Function]}
@@ -271,7 +267,7 @@ exports[`ResetPasswordPage should match reset password default section snapshot 
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="confirm-password-input"
           name="new-password2"
           onBlur={[Function]}
@@ -302,9 +298,7 @@ exports[`ResetPasswordPage should match reset password default section snapshot 
         <span
           className="d-flex align-items-center justify-content-center"
         >
-          <span>
-            Reset my password
-          </span>
+          Reset my password
         </span>
       </button>
     </form>
@@ -382,7 +376,7 @@ exports[`ResetPasswordPage show spinner component during token validation 1`] = 
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="reset-password-input"
           name="new-password1"
           onBlur={[Function]}
@@ -406,7 +400,7 @@ exports[`ResetPasswordPage show spinner component during token validation 1`] = 
         </label>
         <input
           aria-describedby=""
-          className="form-control"
+          className="form-control border-gray-600"
           id="confirm-password-input"
           name="new-password2"
           onBlur={[Function]}
@@ -437,9 +431,7 @@ exports[`ResetPasswordPage show spinner component during token validation 1`] = 
         <span
           className="d-flex align-items-center justify-content-center"
         >
-          <span>
-            Reset my password
-          </span>
+          Reset my password
         </span>
       </button>
     </form>


### PR DESCRIPTION
Color selected for border is #6C757D (grey variant) to fix contrast. 
See paragon colors => https://edx.github.io/paragon/foundations/colors
Tool to check =>  https://webaim.org/resources/contrastchecker/?fcolor=6C757D&bcolor=FBFAF9

Snapshots
![Screen Shot 2021-03-16 at 3 11 44 AM](https://user-images.githubusercontent.com/373677/111229931-9bff6b00-8608-11eb-949c-11522d850912.png)
![Screen Shot 2021-03-16 at 3 11 57 AM](https://user-images.githubusercontent.com/373677/111229943-a02b8880-8608-11eb-91e4-7663eae30101.png)
![Screen Shot 2021-03-16 at 3 12 45 AM](https://user-images.githubusercontent.com/373677/111229957-a3267900-8608-11eb-82bb-685a98dcc3fd.png)
![Screen Shot 2021-03-16 at 3 11 27 AM](https://user-images.githubusercontent.com/373677/111229972-aa4d8700-8608-11eb-8ed7-832d19948abb.png)



VAN-381