### PR TITLE
VAN-384: Add accessible names for TPA buttons

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -115,12 +115,6 @@ $apple-focus-black: $apple-black;
   height: 35px;
 }
 
-.provider-name {
-  font-size: 13px;
-  text-align: left;
-  line-height: 95%;
-}
-
 .btn-oa2-facebook {
   color: $white;
   border-color: $facebook-blue;

--- a/src/common-components/SocialAuthProviders.jsx
+++ b/src/common-components/SocialAuthProviders.jsx
@@ -2,13 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { getConfig } from '@edx/frontend-platform';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSignInAlt } from '@fortawesome/free-solid-svg-icons';
 
+import messages from './messages';
 import { LOGIN_PAGE, SUPPORTED_ICON_CLASSES } from '../data/constants';
 
 function SocialAuthProviders(props) {
-  const { referrer, socialAuthProviders } = props;
+  const { intl, referrer, socialAuthProviders } = props;
 
   function handleSubmit(e) {
     e.preventDefault();
@@ -27,9 +29,8 @@ function SocialAuthProviders(props) {
       onClick={handleSubmit}
     >
       {provider.iconImage ? (
-        <div className="mx-auto" aria-hidden="true">
+        <div className="ml-auto" aria-hidden="true">
           <img className="icon-image" src={provider.iconImage} alt={`icon ${provider.name}`} />
-          <span className="pl-2" aria-hidden="true">{provider.name}</span>
         </div>
       )
         : (
@@ -39,10 +40,14 @@ function SocialAuthProviders(props) {
                 icon={SUPPORTED_ICON_CLASSES.includes(provider.iconClass) ? ['fab', provider.iconClass] : faSignInAlt}
               />
             </div>
-            <span className="pl-2 provider-name" aria-hidden="true">{provider.name}</span>
           </>
         )}
-
+      <span id="provider-name" className="mr-auto pl-2" aria-hidden="true">{provider.name}</span>
+      <span className="sr-only">
+        {referrer === LOGIN_PAGE
+          ? intl.formatMessage(messages['sso.sign.in.with'], { providerName: provider.name })
+          : intl.formatMessage(messages['sso.create.account.using'], { providerName: provider.name })}
+      </span>
     </button>
   ));
 
@@ -55,6 +60,7 @@ SocialAuthProviders.defaultProps = {
 };
 
 SocialAuthProviders.propTypes = {
+  intl: intlShape.isRequired,
   referrer: PropTypes.string,
   socialAuthProviders: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string,
@@ -66,4 +72,4 @@ SocialAuthProviders.propTypes = {
   })),
 };
 
-export default SocialAuthProviders;
+export default injectIntl(SocialAuthProviders);

--- a/src/common-components/messages.jsx
+++ b/src/common-components/messages.jsx
@@ -49,6 +49,17 @@ const messages = defineMessages({
     defaultMessage: 'Show me other ways to sign in or register',
     description: 'Button text for login',
   },
+  // social auth providers
+  'sso.sign.in.with': {
+    id: 'sso.sign.in.with',
+    defaultMessage: 'Sign in with {providerName}',
+    description: 'Screen reader text that appears before social auth provider name',
+  },
+  'sso.create.account.using': {
+    id: 'sso.create.account.using',
+    defaultMessage: 'Create account using {providerName}',
+    description: 'Screen reader text that appears before social auth provider name',
+  },
 });
 
 export default messages;

--- a/src/common-components/tests/__snapshots__/SocialAuthProviders.test.jsx.snap
+++ b/src/common-components/tests/__snapshots__/SocialAuthProviders.test.jsx.snap
@@ -32,9 +32,15 @@ exports[`SocialAuthProviders should match social auth provider with default icon
   </div>
   <span
     aria-hidden="true"
-    className="pl-2 provider-name"
+    className="mr-auto pl-2"
+    id="provider-name"
   >
     Apple
+  </span>
+  <span
+    className="sr-only"
+  >
+    Sign in with Apple
   </span>
 </button>
 `;
@@ -71,9 +77,15 @@ exports[`SocialAuthProviders should match social auth provider with iconClass sn
   </div>
   <span
     aria-hidden="true"
-    className="pl-2 provider-name"
+    className="mr-auto pl-2"
+    id="provider-name"
   >
     Apple
+  </span>
+  <span
+    className="sr-only"
+  >
+    Sign in with Apple
   </span>
 </button>
 `;
@@ -89,20 +101,26 @@ Array [
   >
     <div
       aria-hidden="true"
-      className="mx-auto"
+      className="ml-auto"
     >
       <img
         alt="icon Apple"
         className="icon-image"
         src="https://edx.devstack.lms/logo.png"
       />
-      <span
-        aria-hidden="true"
-        className="pl-2"
-      >
-        Apple
-      </span>
     </div>
+    <span
+      aria-hidden="true"
+      className="mr-auto pl-2"
+      id="provider-name"
+    >
+      Apple
+    </span>
+    <span
+      className="sr-only"
+    >
+      Sign in with Apple
+    </span>
   </button>,
   <button
     className="btn-social btn-oa2-facebook "
@@ -113,20 +131,26 @@ Array [
   >
     <div
       aria-hidden="true"
-      className="mx-auto"
+      className="ml-auto"
     >
       <img
         alt="icon Facebook"
         className="icon-image"
         src="https://edx.devstack.lms/facebook-logo.png"
       />
-      <span
-        aria-hidden="true"
-        className="pl-2"
-      >
-        Facebook
-      </span>
     </div>
+    <span
+      aria-hidden="true"
+      className="mr-auto pl-2"
+      id="provider-name"
+    >
+      Facebook
+    </span>
+    <span
+      className="sr-only"
+    >
+      Sign in with Facebook
+    </span>
   </button>,
 ]
 `;

--- a/src/login/tests/LoginPage.test.jsx
+++ b/src/login/tests/LoginPage.test.jsx
@@ -455,7 +455,7 @@ describe('LoginPage', () => {
     appleProvider.iconImage = null;
 
     const loginPage = mount(reduxWrapper(<IntlLoginPage {...props} />));
-    expect(loginPage.find(`button#${appleProvider.id}`).find('span').text()).toEqual(expectedMessage);
+    expect(loginPage.find(`button#${appleProvider.id}`).find('span#provider-name').text()).toEqual(expectedMessage);
   });
 
   it('should render tpa button for tpa_hint id in secondary provider', () => {

--- a/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
+++ b/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
@@ -169,20 +169,26 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
         >
           <div
             aria-hidden="true"
-            className="mx-auto"
+            className="ml-auto"
           >
             <img
               alt="icon Apple"
               className="icon-image"
               src="https://edx.devstack.lms/logo.png"
             />
-            <span
-              aria-hidden="true"
-              className="pl-2"
-            >
-              Apple
-            </span>
           </div>
+          <span
+            aria-hidden="true"
+            className="mr-auto pl-2"
+            id="provider-name"
+          >
+            Apple
+          </span>
+          <span
+            className="sr-only"
+          >
+            Sign in with Apple
+          </span>
         </button>
       </div>
     </div>

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -675,7 +675,7 @@ describe('RegistrationPageTests', () => {
     appleProvider.iconImage = null;
 
     const registerPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
-    expect(registerPage.find(`button#${appleProvider.id}`).find('span').text()).toEqual(expectedMessage);
+    expect(registerPage.find(`button#${appleProvider.id}`).find('span#provider-name').text()).toEqual(expectedMessage);
   });
 
   it('should render tpa button for tpa_hint id in secondary provider', () => {

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -1535,20 +1535,26 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           >
             <div
               aria-hidden="true"
-              className="mx-auto"
+              className="ml-auto"
             >
               <img
                 alt="icon Apple"
                 className="icon-image"
                 src="https://edx.devstack.lms/logo.png"
               />
-              <span
-                aria-hidden="true"
-                className="pl-2"
-              >
-                Apple
-              </span>
             </div>
+            <span
+              aria-hidden="true"
+              className="mr-auto pl-2"
+              id="provider-name"
+            >
+              Apple
+            </span>
+            <span
+              className="sr-only"
+            >
+              Create account using Apple
+            </span>
           </button>
         </div>
       </form>


### PR DESCRIPTION
### Description:
- Add `sr-only` span for all SSO buttons (`sr-only` means invisible/readable by screen reader users only)
- Moved the provider name outside the div and inside the button. 
- Updated tests to reflect the changes

Ticket: https://openedx.atlassian.net/browse/VAN-384