### PR TITLE
Inline links added for tos on register page

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -264,6 +264,11 @@ $apple-focus-black: $apple-black;
   margin-left: -5px;
 }
 
+#honor-code p {
+  margin: 0;
+  padding: 0;
+}
+
 #honor-code a span {
   @extend .sr-only;
 }

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -541,6 +541,7 @@ class RegistrationPage extends React.Component {
                 <div id="honor-code" className="pt-10 small">
                   <FormattedMessage
                     id="register.page.terms.of.service.and.honor.code"
+                    tagName="p"
                     defaultMessage="By creating an account, you agree to the {tosAndHonorCode} and you acknowledge that {platformName} and each
                     Member process your personal data in accordance with the {privacyPolicy}."
                     description="Text that appears on registration form stating honor code and privacy policy"

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -1417,7 +1417,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           className="pt-10 small"
           id="honor-code"
         >
-          <span>
+          <p>
             By creating an account, you agree to the 
             <a
               href="http://tos-and-honot-code.com"
@@ -1455,7 +1455,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
               </span>
             </a>
             .
-          </span>
+          </p>
         </div>
         <div
           className="form-group custom-control pt-10 mb-0"
@@ -2968,7 +2968,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           className="pt-10 small"
           id="honor-code"
         >
-          <span>
+          <p>
             By creating an account, you agree to the 
             <a
               href="http://tos-and-honot-code.com"
@@ -3006,7 +3006,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
               </span>
             </a>
             .
-          </span>
+          </p>
         </div>
         <div
           className="form-group custom-control pt-10 mb-0"
@@ -4480,7 +4480,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           className="pt-10 small"
           id="honor-code"
         >
-          <span>
+          <p>
             By creating an account, you agree to the 
             <a
               href="http://tos-and-honot-code.com"
@@ -4518,7 +4518,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
               </span>
             </a>
             .
-          </span>
+          </p>
         </div>
         <div
           className="form-group custom-control pt-10 mb-0"


### PR DESCRIPTION
VAN-386
<img width="1440" alt="Screen Shot 2021-03-17 at 12 00 04 PM" src="https://user-images.githubusercontent.com/8156837/111427742-5af67c00-8718-11eb-8f18-0bada832a9aa.png">

