### PR TITLE
VAN-380: Add H1 heading to Login Page

### DIFF
--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -206,9 +206,9 @@ class LoginPage extends React.Component {
                 </Hyperlink>
               </p>
               <hr className="mt-0 border-gray-200" />
-              <h3 className="text-left mt-2 mb-3">
+              <h1 className="text-left mt-2 mb-3 h3">
                 {intl.formatMessage(messages['sign.in.heading'])}
-              </h3>
+              </h1>
               <Form className="m-0">
                 <AuthnValidationFormGroup
                   label={intl.formatMessage(messages['email.label'])}

--- a/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
+++ b/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
@@ -25,11 +25,11 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
       <hr
         className="mt-0 border-gray-200"
       />
-      <h3
-        className="text-left mt-2 mb-3"
+      <h1
+        className="text-left mt-2 mb-3 h3"
       >
         Sign in
-      </h3>
+      </h1>
       <form
         className="m-0"
       >
@@ -221,11 +221,11 @@ exports[`LoginPage should match default section snapshot 1`] = `
       <hr
         className="mt-0 border-gray-200"
       />
-      <h3
-        className="text-left mt-2 mb-3"
+      <h1
+        className="text-left mt-2 mb-3 h3"
       >
         Sign in
-      </h3>
+      </h1>
       <form
         className="m-0"
       >
@@ -415,11 +415,11 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
       <hr
         className="mt-0 border-gray-200"
       />
-      <h3
-        className="text-left mt-2 mb-3"
+      <h1
+        className="text-left mt-2 mb-3 h3"
       >
         Sign in
-      </h3>
+      </h1>
       <form
         className="m-0"
       >
@@ -569,11 +569,11 @@ exports[`LoginPage should match pending button state snapshot 1`] = `
       <hr
         className="mt-0 border-gray-200"
       />
-      <h3
-        className="text-left mt-2 mb-3"
+      <h1
+        className="text-left mt-2 mb-3 h3"
       >
         Sign in
-      </h3>
+      </h1>
       <form
         className="m-0"
       >
@@ -760,11 +760,11 @@ exports[`LoginPage should show error message 1`] = `
       <hr
         className="mt-0 border-gray-200"
       />
-      <h3
-        className="text-left mt-2 mb-3"
+      <h1
+        className="text-left mt-2 mb-3 h3"
       >
         Sign in
-      </h3>
+      </h1>
       <form
         className="m-0"
       >


### PR DESCRIPTION
#### Context: 
We use headings (`<h1>`, `<h2>`, etc.) to give a page semantic structure. These are particularly useful for blind learners.  General accessibility guidelines for use of headers include:

- there should be an H1
- there should be only one H1
- Heading levels should correspond to semantic structure consistently (no inversions, changing levels that look like peers, etc.)

----

#### Notes:
- Converted H3 to H1
- Added the css of H3 to H1 so that the page looks same as it did before
<img width="1426" alt="Screenshot 2021-03-22 at 11 10 16 AM" src="https://user-images.githubusercontent.com/40633976/111947596-a2597f80-8aff-11eb-869b-7f5b85eb0ee2.png">
