### PR TITLE
Update h3 headings to h1 for page semantics

### DIFF
--- a/src/common-components/InstitutionLogistration.jsx
+++ b/src/common-components/InstitutionLogistration.jsx
@@ -47,9 +47,9 @@ const InstitutionLogistration = props => {
               {buttonTitle}
             </Hyperlink>
           </div>
-          <h3 className="mt-3 mb-4 font-weight-normal">
+          <h1 className="mt-3 mb-4 font-weight-normal h3">
             {headingTitle}
-          </h3>
+          </h1>
           <p className="mb-2">
             {intl.formatMessage(messages['institution.login.page.sub.heading'])}
           </p>

--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -98,9 +98,9 @@ const ForgotPasswordPage = (props) => {
             <div className="d-flex flex-column">
               <Form className="mw-500">
                 { getErrorMessage(errors) }
-                <h3 className="mt-3">
+                <h1 className="mt-3 h3">
                   {intl.formatMessage(messages['forgot.password.page.heading'])}
-                </h3>
+                </h1>
                 <p className="mb-4">
                   {intl.formatMessage(messages['forgot.password.page.instructions'])}
                 </p>

--- a/src/forgot-password/tests/__snapshots__/ForgotPasswordPage.test.jsx.snap
+++ b/src/forgot-password/tests/__snapshots__/ForgotPasswordPage.test.jsx.snap
@@ -10,11 +10,11 @@ exports[`ForgotPasswordPage should match default section snapshot 1`] = `
     <form
       className="mw-500"
     >
-      <h3
-        className="mt-3"
+      <h1
+        className="mt-3 h3"
       >
         Password assistance
-      </h3>
+      </h1>
       <p
         className="mb-4"
       >
@@ -133,11 +133,11 @@ exports[`ForgotPasswordPage should match forbidden section snapshot 1`] = `
           </li>
         </ul>
       </div>
-      <h3
-        className="mt-3"
+      <h1
+        className="mt-3 h3"
       >
         Password assistance
-      </h3>
+      </h1>
       <p
         className="mb-4"
       >
@@ -241,11 +241,11 @@ exports[`ForgotPasswordPage should match pending section snapshot 1`] = `
     <form
       className="mw-500"
     >
-      <h3
-        className="mt-3"
+      <h1
+        className="mt-3 h3"
       >
         Password assistance
-      </h3>
+      </h1>
       <p
         className="mb-4"
       >

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -466,7 +466,7 @@ class RegistrationPage extends React.Component {
                 </Hyperlink>
               </p>
               <hr className="mb-3 border-gray-200" />
-              <h3 className="mb-3">{intl.formatMessage(messages['create.a.new.account'])}</h3>
+              <h1 className="mb-3 h3">{intl.formatMessage(messages['create.a.new.account'])}</h1>
               <Form className="form-group">
                 <AuthnValidationFormGroup
                   label={intl.formatMessage(messages['fullname.label'])}

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -24,11 +24,11 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
       <hr
         className="mb-3 border-gray-200"
       />
-      <h3
-        className="mb-3"
+      <h1
+        className="mb-3 h3"
       >
         Create a new account
-      </h3>
+      </h1>
       <form
         className="form-group"
       >
@@ -1593,11 +1593,11 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
       <hr
         className="mb-3 border-gray-200"
       />
-      <h3
-        className="mb-3"
+      <h1
+        className="mb-3 h3"
       >
         Create a new account
-      </h3>
+      </h1>
       <form
         className="form-group"
       >
@@ -3117,11 +3117,11 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
       <hr
         className="mb-3 border-gray-200"
       />
-      <h3
-        className="mb-3"
+      <h1
+        className="mb-3 h3"
       >
         Create a new account
-      </h3>
+      </h1>
       <form
         className="form-group"
       >

--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -141,9 +141,9 @@ const ResetPasswordPage = (props) => {
               </Alert>
             ) : null}
             <Form>
-              <h3 className="mt-3">
+              <h1 className="mt-3 h3">
                 {intl.formatMessage(messages['reset.password.page.heading'])}
-              </h3>
+              </h1>
               <p className="mb-4">
                 {intl.formatMessage(messages['reset.password.page.instructions'])}
               </p>

--- a/src/reset-password/tests/__snapshots__/ResetPasswordPage.test.jsx.snap
+++ b/src/reset-password/tests/__snapshots__/ResetPasswordPage.test.jsx.snap
@@ -11,11 +11,11 @@ exports[`ResetPasswordPage should match invalid token message section snapshot 1
     <form
       className=""
     >
-      <h3
-        className="mt-3"
+      <h1
+        className="mt-3 h3"
       >
         Reset your password
-      </h3>
+      </h1>
       <p
         className="mb-4"
       >
@@ -112,11 +112,11 @@ exports[`ResetPasswordPage should match pending reset message section snapshot 1
     <form
       className=""
     >
-      <h3
-        className="mt-3"
+      <h1
+        className="mt-3 h3"
       >
         Reset your password
-      </h3>
+      </h1>
       <p
         className="mb-4"
       >
@@ -234,11 +234,11 @@ exports[`ResetPasswordPage should match reset password default section snapshot 
     <form
       className=""
     >
-      <h3
-        className="mt-3"
+      <h1
+        className="mt-3 h3"
       >
         Reset your password
-      </h3>
+      </h1>
       <p
         className="mb-4"
       >
@@ -373,11 +373,11 @@ exports[`ResetPasswordPage show spinner component during token validation 1`] = 
     <form
       className=""
     >
-      <h3
-        className="mt-3"
+      <h1
+        className="mt-3 h3"
       >
         Reset your password
-      </h3>
+      </h1>
       <p
         className="mb-4"
       >


### PR DESCRIPTION
#### Context:
We use headings (`<h1>`, `<h2>`, etc.) to give a page semantic structure. These are particularly useful for blind learners. General accessibility guidelines for use of headers include:
- there should be an H1
- there should be only one H1
- heading levels should correspond to semantic structure consistently (no inversions, changing levels that look like peers, etc.)

----

####Notes:
- Converted H3 to H1
- Added the css of H3 to H1 so that the page looks same as it did before
- This change was already done for login page here: https://github.com/edx/frontend-app-authn/pull/216

Ticket: https://openedx.atlassian.net/browse/VAN-426