### PR TITLE
Send user attributes to hotjar

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -432,6 +432,13 @@ class RegistrationPage extends React.Component {
       );
     }
 
+    if (this.props.registrationResult.success && window.hj) {
+      window.hj('identify', null, {
+        signedUp: new Date().toISOString(),
+        testAccount: this.state.username.includes('hotjarTest'), // TODO: Remove this after testing
+      });
+    }
+
     return (
       <>
         <Helmet>

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -526,6 +526,8 @@ describe('RegistrationPageTests', () => {
 
   it('should match url after redirection', () => {
     const dasboardUrl = 'http://test.com/testing-dashboard/';
+    Object.defineProperty(global.window, 'hj', { value: () => {} });
+
     store = mockStore({
       ...initialState,
       register: {


### PR DESCRIPTION
Once the user has signed up successfully, send custom user attribute to hotjar. These can be used to configure hotjar surveys and other feedback tools. 

#### Other information:
- I am following this guide to setup user attributes: https://help.hotjar.com/hc/en-us/articles/360038394053/
- I am not sending edX user id to identify call and it will automatically use the hotjar user id. 
- **Test Account** attribute will be removed after testing 


[VAN-291](https://openedx.atlassian.net/browse/VAN-291)