### PR TITLE
Make optional fields configurable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -23,4 +23,4 @@ AUTHN_MINIMAL_HEADER=true
 LOGIN_ISSUE_SUPPORT_LINK=''
 TOS_AND_HONOR_CODE='http://localhost:18000/honor'
 PRIVACY_POLICY='http://localhost:18000/privacy'
-REGISTRATION_OPTIONAL_FIELDS='gender,goals,level_of_education,year_of_birth'
+REGISTRATION_OPTIONAL_FIELDS='gender,goals,levelOfEducation,yearOfBirth'

--- a/src/register/OptionalFields.jsx
+++ b/src/register/OptionalFields.jsx
@@ -9,7 +9,9 @@ import messages from './messages';
 import { AuthnValidationFormGroup } from '../common-components';
 
 const OptionalFields = (props) => {
-  const { intl, onChangeHandler, values } = props;
+  const {
+    intl, optionalFields, onChangeHandler, values,
+  } = props;
 
   const getOptions = () => ({
     yearOfBirthOptions: [{
@@ -28,56 +30,65 @@ const OptionalFields = (props) => {
 
   return (
     <>
-      <AuthnValidationFormGroup
-        label={intl.formatMessage(messages['registration.field.gender.options.label'])}
-        for="gender"
-        name="gender"
-        type="select"
-        key="gender"
-        value={values.gender}
-        className="mb-20 opt-inline-field data-hj-suppress"
-        onChange={(e) => onChangeHandler('gender', e.target.value)}
-        selectOptions={getOptions().genderOptions}
-      />
-      <AuthnValidationFormGroup
-        label={intl.formatMessage(messages['registration.year.of.birth.label'])}
-        for="yearOfBirth"
-        name="yearOfBirth"
-        type="select"
-        key="yearOfBirth"
-        value={values.yearOfBirth}
-        className="mb-20 opt-inline-field opt-year-field data-hj-suppress"
-        onChange={(e) => onChangeHandler('yearOfBirth', e.target.value)}
-        selectOptions={getOptions().yearOfBirthOptions}
-      />
-      <AuthnValidationFormGroup
-        label={intl.formatMessage(messages['registration.field.education.levels.label'])}
-        for="levelOfEducation"
-        name="levelOfEducation"
-        type="select"
-        key="levelOfEducation"
-        value={values.levelOfEducation}
-        className="mb-20 data-hj-suppress"
-        onChange={(e) => onChangeHandler('levelOfEducation', e.target.value)}
-        selectOptions={getOptions().educationLevelOptions}
-      />
-      <AuthnValidationFormGroup
-        label={intl.formatMessage(messages['registration.goals.label'])}
-        for="goals"
-        name="goals"
-        type="textarea"
-        key="goals"
-        value={values.goals}
-        className="mb-20"
-        onChange={(e) => onChangeHandler('goals', e.target.value)}
-        inputFieldStyle="border-gray-600"
-      />
+      {optionalFields.includes('gender') && (
+        <AuthnValidationFormGroup
+          label={intl.formatMessage(messages['registration.field.gender.options.label'])}
+          for="gender"
+          name="gender"
+          type="select"
+          key="gender"
+          value={values.gender}
+          className="mb-20 data-hj-suppress"
+          onChange={(e) => onChangeHandler('gender', e.target.value)}
+          selectOptions={getOptions().genderOptions}
+        />
+      )}
+      {optionalFields.includes('yearOfBirth') && (
+        <AuthnValidationFormGroup
+          label={intl.formatMessage(messages['registration.year.of.birth.label'])}
+          for="yearOfBirth"
+          name="yearOfBirth"
+          type="select"
+          key="yearOfBirth"
+          value={values.yearOfBirth}
+          className="mb-20 data-hj-suppress"
+          onChange={(e) => onChangeHandler('yearOfBirth', e.target.value)}
+          selectOptions={getOptions().yearOfBirthOptions}
+        />
+      )}
+      {optionalFields.includes('levelOfEducation') && (
+        <AuthnValidationFormGroup
+          label={intl.formatMessage(messages['registration.field.education.levels.label'])}
+          for="levelOfEducation"
+          name="levelOfEducation"
+          type="select"
+          key="levelOfEducation"
+          value={values.levelOfEducation}
+          className="mb-20 data-hj-suppress"
+          onChange={(e) => onChangeHandler('levelOfEducation', e.target.value)}
+          selectOptions={getOptions().educationLevelOptions}
+        />
+      )}
+      {optionalFields.includes('goals') && (
+        <AuthnValidationFormGroup
+          label={intl.formatMessage(messages['registration.goals.label'])}
+          for="goals"
+          name="goals"
+          type="textarea"
+          key="goals"
+          value={values.goals}
+          className="mb-20"
+          onChange={(e) => onChangeHandler('goals', e.target.value)}
+          inputFieldStyle="border-gray-600"
+        />
+      )}
     </>
   );
 };
 
 OptionalFields.propTypes = {
   intl: intlShape.isRequired,
+  optionalFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   onChangeHandler: PropTypes.func.isRequired,
   values: PropTypes.shape({
     gender: PropTypes.string,

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -27,7 +27,7 @@ const mockStore = configureStore();
 describe('RegistrationPageTests', () => {
   mergeConfig({
     PRIVACY_POLICY: 'http://privacy-policy.com',
-    REGISTRATION_OPTIONAL_FIELDS: 'gender,goals,level_of_education,year_of_birth',
+    REGISTRATION_OPTIONAL_FIELDS: 'gender,goals,levelOfEducation,yearOfBirth',
     TOS_AND_HONOR_CODE: 'http://tos-and-honot-code.com',
   });
 
@@ -178,7 +178,7 @@ describe('RegistrationPageTests', () => {
     expect(registrationPage.find('input#optional').length).toEqual(0);
 
     mergeConfig({
-      REGISTRATION_OPTIONAL_FIELDS: 'gender,goals,level_of_education,year_of_birth',
+      REGISTRATION_OPTIONAL_FIELDS: 'gender,goals,levelOfEducation,yearOfBirth',
     });
 
     registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));


### PR DESCRIPTION
As part of VAN-405, changes are required to remove the optional fields, instead of removing them completely from code base I have made them configurable which will allow us to enable it back if we need it. If it's not needed in future we can remove it completely.

##### Empty `REGISTRATION_OPTIONAL_FIELDS` process env gives us:
<img width="400" alt="Screenshot 2021-04-06 at 5 57 09 PM" src="https://user-images.githubusercontent.com/40633976/113714199-94ac1880-9701-11eb-8021-c48a1e96ba0a.png">

I have removed custom class from the fields because enabling some fields was causing css to break
<img width="400" alt="Screenshot 2021-04-06 at 5 48 45 PM" src="https://user-images.githubusercontent.com/40633976/113713168-6f6ada80-9700-11eb-8fec-201daee7a14a.png">
 



[VAN-405](https://openedx.atlassian.net/browse/VAN-405)