### PR TITLE
VAN-405: Redesign social auth provider component

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -63,7 +63,6 @@ $apple-focus-black: $apple-black;
 .btn-social {
   display: flex;
   flex-direction: row;
-  justify-content: flex-start;
   align-items: center;
 
   margin-bottom: 1rem;
@@ -97,10 +96,6 @@ $apple-focus-black: $apple-black;
 }
 
 .tpa-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-
   margin: 0 !important;
 }
 
@@ -306,13 +301,11 @@ $apple-focus-black: $apple-black;
 
 @media (max-width: 600px) {
   .btn-social {
-    width: 47%;
+    width: 100%;
     margin-bottom: 0.75rem;
+    margin-right: 0 !important;
   }
 
-  .tpa-container {
-    justify-content: center;
-  }
   .form-control {
     width: 100%;
   }

--- a/src/common-components/SocialAuthProviders.jsx
+++ b/src/common-components/SocialAuthProviders.jsx
@@ -29,7 +29,7 @@ function SocialAuthProviders(props) {
       onClick={handleSubmit}
     >
       {provider.iconImage ? (
-        <div className="ml-auto" aria-hidden="true">
+        <div aria-hidden="true">
           <img className="icon-image" src={provider.iconImage} alt={`icon ${provider.name}`} />
         </div>
       )

--- a/src/common-components/tests/__snapshots__/SocialAuthProviders.test.jsx.snap
+++ b/src/common-components/tests/__snapshots__/SocialAuthProviders.test.jsx.snap
@@ -101,7 +101,6 @@ Array [
   >
     <div
       aria-hidden="true"
-      className="ml-auto"
     >
       <img
         alt="icon Apple"
@@ -131,7 +130,6 @@ Array [
   >
     <div
       aria-hidden="true"
-      className="ml-auto"
     >
       <img
         alt="icon Facebook"

--- a/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
+++ b/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
@@ -169,7 +169,6 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
         >
           <div
             aria-hidden="true"
-            className="ml-auto"
           >
             <img
               alt="icon Apple"

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -1535,7 +1535,6 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           >
             <div
               aria-hidden="true"
-              className="ml-auto"
             >
               <img
                 alt="icon Apple"


### PR DESCRIPTION
updated social auth providers to match for login and register page
|Before|After|
|---|---|
<img width="300" alt="Screenshot 2021-04-08 at 5 22 37 PM" src="https://user-images.githubusercontent.com/40633976/114025937-1f6e4e00-988f-11eb-8819-576c0112574b.png">|<img width="300" alt="Screenshot 2021-04-08 at 5 14 20 PM" src="https://user-images.githubusercontent.com/40633976/114025786-f2ba3680-988e-11eb-988f-b501207340eb.png">

#### Mobile

|Before|After|
|---|---|
<img width="250" alt="Screenshot 2021-04-08 at 5 23 00 PM" src="https://user-images.githubusercontent.com/40633976/114025948-239a6b80-988f-11eb-9ec6-59b5a5a421d9.png">|<img width="250" alt="Screenshot 2021-04-08 at 5 14 48 PM" src="https://user-images.githubusercontent.com/40633976/114025803-f64dbd80-988e-11eb-8f33-5561614900cd.png">
