### PR TITLE
Update optional fields to use updated paragon components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3828,9 +3828,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "13.16.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-13.16.1.tgz",
-      "integrity": "sha512-8GxeS0OQLKJKrkqUa6HRk+wi/96IvhuY6JjjQYIf4+SA6TXLu57SwvtsQN6sLuB3PTxnW64WQF3MepvpNo9VpQ==",
+      "version": "13.17.5",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-13.17.5.tgz",
+      "integrity": "sha512-ZLgZU/8kQBfHT3gd1s3w6AQZIOfufqMU4hItB4dSaqVcCX8ECmtE/AAMdwasTNxyhGCzfITuVe8xB9wYOnU/Xw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -21304,9 +21304,9 @@
       }
     },
     "react-popper": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.4.tgz",
-      "integrity": "sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@edx/frontend-component-cookie-policy-banner": "2.1.11",
     "@edx/frontend-component-header": "2.2.4",
     "@edx/frontend-platform": "1.8.4",
-    "@edx/paragon": "13.16.1",
+    "@edx/paragon": "13.17.5",
     "@fortawesome/fontawesome-svg-core": "1.2.32",
     "@fortawesome/free-brands-svg-icons": "5.15.1",
     "@fortawesome/free-regular-svg-icons": "5.15.1",

--- a/src/common-components/tests/AuthnValidationFormGroup.test.jsx
+++ b/src/common-components/tests/AuthnValidationFormGroup.test.jsx
@@ -15,14 +15,14 @@ describe('AuthnCustomValidationFormGroup', () => {
 
   it('should show label in place of placeholder when field is empty', () => {
     const validationFormGroup = mount(<AuthnCustomValidationFormGroup {...props} />);
-    expect(validationFormGroup.find('label').prop('className')).toEqual('pt-10 focus-out form-label');
+    expect(validationFormGroup.find('label').prop('className')).toEqual('pgn__form-label pt-10 focus-out');
   });
 
   it('should show label on top of field when field is focused in', () => {
     const validationFormGroup = mount(<AuthnCustomValidationFormGroup {...props} />);
 
     validationFormGroup.find('input').simulate('focus');
-    expect(validationFormGroup.find('label').prop('className')).toEqual('pt-10 h6 form-label');
+    expect(validationFormGroup.find('label').prop('className')).toEqual('pgn__form-label pt-10 h6');
   });
 
   it('should keep label hidden for checkbox field', () => {
@@ -32,7 +32,7 @@ describe('AuthnCustomValidationFormGroup', () => {
       optionalFieldCheckbox: true,
     };
     const validationFormGroup = mount(<AuthnCustomValidationFormGroup {...props} />);
-    expect(validationFormGroup.find('label').prop('className')).toEqual('sr-only form-label');
+    expect(validationFormGroup.find('label').prop('className')).toEqual('pgn__form-label sr-only');
   });
 
   it('should keep label hidden when input field is not empty', () => {
@@ -41,6 +41,6 @@ describe('AuthnCustomValidationFormGroup', () => {
       value: 'test',
     };
     const validationFormGroup = mount(<AuthnCustomValidationFormGroup {...props} />);
-    expect(validationFormGroup.find('label').prop('className')).toEqual('sr-only form-label');
+    expect(validationFormGroup.find('label').prop('className')).toEqual('pgn__form-label sr-only');
   });
 });

--- a/src/forgot-password/tests/__snapshots__/ForgotPasswordPage.test.jsx.snap
+++ b/src/forgot-password/tests/__snapshots__/ForgotPasswordPage.test.jsx.snap
@@ -24,8 +24,7 @@ exports[`ForgotPasswordPage should match default section snapshot 1`] = `
         className="form-group mb-0 w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="forgot-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           Email
         </label>
@@ -146,8 +145,7 @@ exports[`ForgotPasswordPage should match forbidden section snapshot 1`] = `
         className="form-group mb-0 w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="forgot-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           Email
         </label>
@@ -253,8 +251,7 @@ exports[`ForgotPasswordPage should match pending section snapshot 1`] = `
         className="form-group mb-0 w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="forgot-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           Email
         </label>

--- a/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
+++ b/src/login/tests/__snapshots__/LoginPage.test.jsx.snap
@@ -37,8 +37,7 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="email"
+            className="pgn__form-label pt-10 focus-out"
           >
             Email
           </label>
@@ -62,8 +61,7 @@ exports[`LoginPage should match TPA provider snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="password"
+            className="pgn__form-label pt-10 focus-out"
           >
             Password
           </label>
@@ -232,8 +230,7 @@ exports[`LoginPage should match default section snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="email"
+            className="pgn__form-label pt-10 focus-out"
           >
             Email
           </label>
@@ -257,8 +254,7 @@ exports[`LoginPage should match default section snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="password"
+            className="pgn__form-label pt-10 focus-out"
           >
             Password
           </label>
@@ -426,8 +422,7 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="email"
+            className="pgn__form-label pt-10 focus-out"
           >
             Email
           </label>
@@ -451,8 +446,7 @@ exports[`LoginPage should match forget password alert message snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="password"
+            className="pgn__form-label pt-10 focus-out"
           >
             Password
           </label>
@@ -580,8 +574,7 @@ exports[`LoginPage should match pending button state snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="email"
+            className="pgn__form-label pt-10 focus-out"
           >
             Email
           </label>
@@ -605,8 +598,7 @@ exports[`LoginPage should match pending button state snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="password"
+            className="pgn__form-label pt-10 focus-out"
           >
             Password
           </label>
@@ -771,8 +763,7 @@ exports[`LoginPage should show error message 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="email"
+            className="pgn__form-label pt-10 focus-out"
           >
             Email
           </label>
@@ -796,8 +787,7 @@ exports[`LoginPage should show error message 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="password"
+            className="pgn__form-label pt-10 focus-out"
           >
             Password
           </label>

--- a/src/register/OptionalFields.jsx
+++ b/src/register/OptionalFields.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Form, Icon } from '@edx/paragon';
+import { ExpandMore } from '@edx/paragon/icons';
 
 import { EDUCATION_LEVELS, GENDER_OPTIONS, YEAR_OF_BIRTH_OPTIONS } from './data/constants';
 import messages from './messages';
-
-import { AuthnValidationFormGroup } from '../common-components';
 
 const OptionalFields = (props) => {
   const {
@@ -14,75 +14,74 @@ const OptionalFields = (props) => {
   } = props;
 
   const getOptions = () => ({
-    yearOfBirthOptions: [{
-      value: '',
-      label: intl.formatMessage(messages['registration.year.of.birth.label']),
-    }].concat(YEAR_OF_BIRTH_OPTIONS),
-    educationLevelOptions: EDUCATION_LEVELS.map(key => ({
-      value: key,
-      label: intl.formatMessage(messages[`registration.field.education.levels.${key || 'label'}`]),
-    })),
-    genderOptions: GENDER_OPTIONS.map(key => ({
-      value: key,
-      label: intl.formatMessage(messages[`registration.field.gender.options.${key || 'label'}`]),
-    })),
+    yearOfBirthOptions: YEAR_OF_BIRTH_OPTIONS.map(({ value, label }) => (
+      <option key={value} value={value}>{label}</option>
+    )),
+    educationLevelOptions: EDUCATION_LEVELS.map(key => (
+      <option key={key} value={key}>{intl.formatMessage(messages[`registration.field.education.levels.${key || 'label'}`])}</option>
+    )),
+    genderOptions: GENDER_OPTIONS.map(key => (
+      <option key={key} value={key}>{intl.formatMessage(messages[`registration.field.gender.options.${key || 'label'}`])}</option>
+    )),
   });
 
   return (
-    <>
+    <div className="mt-3">
       {optionalFields.includes('gender') && (
-        <AuthnValidationFormGroup
-          label={intl.formatMessage(messages['registration.field.gender.options.label'])}
-          for="gender"
-          name="gender"
-          type="select"
-          key="gender"
-          value={values.gender}
-          className="mb-20 data-hj-suppress"
-          onChange={(e) => onChangeHandler('gender', e.target.value)}
-          selectOptions={getOptions().genderOptions}
-        />
+        <Form.Group controlId="gender">
+          <Form.Control
+            as="select"
+            name="gender"
+            value={values.gender}
+            onChange={(e) => onChangeHandler('gender', e.target.value)}
+            trailingElement={<Icon src={ExpandMore} />}
+            floatingLabel={intl.formatMessage(messages['registration.field.gender.options.label'])}
+          >
+            {getOptions().genderOptions}
+          </Form.Control>
+        </Form.Group>
       )}
       {optionalFields.includes('yearOfBirth') && (
-        <AuthnValidationFormGroup
-          label={intl.formatMessage(messages['registration.year.of.birth.label'])}
-          for="yearOfBirth"
-          name="yearOfBirth"
-          type="select"
-          key="yearOfBirth"
-          value={values.yearOfBirth}
-          className="mb-20 data-hj-suppress"
-          onChange={(e) => onChangeHandler('yearOfBirth', e.target.value)}
-          selectOptions={getOptions().yearOfBirthOptions}
-        />
+        <Form.Group controlId="yearOfBirth">
+          <Form.Control
+            as="select"
+            name="yearOfBirth"
+            value={values.yearOfBirth}
+            onChange={(e) => onChangeHandler('yearOfBirth', e.target.value)}
+            trailingElement={<Icon src={ExpandMore} />}
+            floatingLabel={intl.formatMessage(messages['registration.year.of.birth.label'])}
+          >
+            <option value="">{intl.formatMessage(messages['registration.year.of.birth.label'])}</option>
+            {getOptions().yearOfBirthOptions}
+          </Form.Control>
+        </Form.Group>
       )}
       {optionalFields.includes('levelOfEducation') && (
-        <AuthnValidationFormGroup
-          label={intl.formatMessage(messages['registration.field.education.levels.label'])}
-          for="levelOfEducation"
-          name="levelOfEducation"
-          type="select"
-          key="levelOfEducation"
-          value={values.levelOfEducation}
-          className="mb-20 data-hj-suppress"
-          onChange={(e) => onChangeHandler('levelOfEducation', e.target.value)}
-          selectOptions={getOptions().educationLevelOptions}
-        />
+        <Form.Group controlId="levelOfEducation">
+          <Form.Control
+            as="select"
+            name="levelOfEducation"
+            value={values.levelOfEducation}
+            onChange={(e) => onChangeHandler('levelOfEducation', e.target.value)}
+            trailingElement={<Icon src={ExpandMore} />}
+            floatingLabel={intl.formatMessage(messages['registration.field.education.levels.label'])}
+          >
+            {getOptions().educationLevelOptions}
+          </Form.Control>
+        </Form.Group>
       )}
       {optionalFields.includes('goals') && (
-        <AuthnValidationFormGroup
-          label={intl.formatMessage(messages['registration.goals.label'])}
-          for="goals"
-          name="goals"
-          type="textarea"
-          key="goals"
-          value={values.goals}
-          className="mb-20"
-          onChange={(e) => onChangeHandler('goals', e.target.value)}
-          inputFieldStyle="border-gray-600"
-        />
+        <Form.Group controlId="goals">
+          <Form.Control
+            as="textarea"
+            name="goals"
+            value={values.goals}
+            onChange={(e) => onChangeHandler('goals', e.target.value)}
+            floatingLabel={intl.formatMessage(messages['registration.goals.label'])}
+          />
+        </Form.Group>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
+++ b/src/register/tests/__snapshots__/RegistrationPage.test.jsx.snap
@@ -36,8 +36,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="name"
+            className="pgn__form-label pt-10 focus-out"
           >
             Full name (required)
           </label>
@@ -61,8 +60,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           className="form-group data-hj-suppress"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="username"
+            className="pgn__form-label pt-10 focus-out"
           >
             Public username (required)
           </label>
@@ -86,8 +84,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           className="form-group data-hj-suppress"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="email"
+            className="pgn__form-label pt-10 focus-out"
           >
             Email (required)
           </label>
@@ -111,8 +108,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="password"
+            className="pgn__form-label pt-10 focus-out"
           >
             Password (required)
           </label>
@@ -136,8 +132,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           className="form-group mb-0 data-hj-suppress"
         >
           <label
-            className="sr-only form-label"
-            htmlFor="country"
+            className="pgn__form-label sr-only"
           >
             Country or region of residence (required)
           </label>
@@ -1466,8 +1461,7 @@ exports[`RegistrationPageTests should match TPA provider snapshot 1`] = `
           className="form-group custom-control pt-10 mb-0"
         >
           <label
-            className="sr-only form-label"
-            htmlFor="optional"
+            className="pgn__form-label sr-only"
           >
             Support education research by providing additional information. (Optional)
           </label>
@@ -1598,8 +1592,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="name"
+            className="pgn__form-label pt-10 focus-out"
           >
             Full name (required)
           </label>
@@ -1623,8 +1616,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           className="form-group data-hj-suppress"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="username"
+            className="pgn__form-label pt-10 focus-out"
           >
             Public username (required)
           </label>
@@ -1648,8 +1640,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           className="form-group data-hj-suppress"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="email"
+            className="pgn__form-label pt-10 focus-out"
           >
             Email (required)
           </label>
@@ -1673,8 +1664,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="password"
+            className="pgn__form-label pt-10 focus-out"
           >
             Password (required)
           </label>
@@ -1698,8 +1688,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           className="form-group mb-0 data-hj-suppress"
         >
           <label
-            className="sr-only form-label"
-            htmlFor="country"
+            className="pgn__form-label sr-only"
           >
             Country or region of residence (required)
           </label>
@@ -3028,8 +3017,7 @@ exports[`RegistrationPageTests should match default section snapshot 1`] = `
           className="form-group custom-control pt-10 mb-0"
         >
           <label
-            className="sr-only form-label"
-            htmlFor="optional"
+            className="pgn__form-label sr-only"
           >
             Support education research by providing additional information. (Optional)
           </label>
@@ -3116,8 +3104,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="name"
+            className="pgn__form-label pt-10 focus-out"
           >
             Full name (required)
           </label>
@@ -3141,8 +3128,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           className="form-group data-hj-suppress"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="username"
+            className="pgn__form-label pt-10 focus-out"
           >
             Public username (required)
           </label>
@@ -3166,8 +3152,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           className="form-group data-hj-suppress"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="email"
+            className="pgn__form-label pt-10 focus-out"
           >
             Email (required)
           </label>
@@ -3191,8 +3176,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           className="form-group"
         >
           <label
-            className="pt-10 focus-out form-label"
-            htmlFor="password"
+            className="pgn__form-label pt-10 focus-out"
           >
             Password (required)
           </label>
@@ -3216,8 +3200,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           className="form-group mb-0 data-hj-suppress"
         >
           <label
-            className="sr-only form-label"
-            htmlFor="country"
+            className="pgn__form-label sr-only"
           >
             Country or region of residence (required)
           </label>
@@ -4546,8 +4529,7 @@ exports[`RegistrationPageTests should match pending button state snapshot 1`] = 
           className="form-group custom-control pt-10 mb-0"
         >
           <label
-            className="sr-only form-label"
-            htmlFor="optional"
+            className="pgn__form-label sr-only"
           >
             Support education research by providing additional information. (Optional)
           </label>

--- a/src/reset-password/tests/__snapshots__/ResetPasswordPage.test.jsx.snap
+++ b/src/reset-password/tests/__snapshots__/ResetPasswordPage.test.jsx.snap
@@ -25,8 +25,7 @@ exports[`ResetPasswordPage should match invalid token message section snapshot 1
         className="form-group w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="reset-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           New password
         </label>
@@ -50,8 +49,7 @@ exports[`ResetPasswordPage should match invalid token message section snapshot 1
         className="form-group w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="confirm-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           Confirm password
         </label>
@@ -124,8 +122,7 @@ exports[`ResetPasswordPage should match pending reset message section snapshot 1
         className="form-group w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="reset-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           New password
         </label>
@@ -149,8 +146,7 @@ exports[`ResetPasswordPage should match pending reset message section snapshot 1
         className="form-group w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="confirm-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           Confirm password
         </label>
@@ -244,8 +240,7 @@ exports[`ResetPasswordPage should match reset password default section snapshot 
         className="form-group w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="reset-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           New password
         </label>
@@ -269,8 +264,7 @@ exports[`ResetPasswordPage should match reset password default section snapshot 
         className="form-group w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="confirm-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           Confirm password
         </label>
@@ -381,8 +375,7 @@ exports[`ResetPasswordPage show spinner component during token validation 1`] = 
         className="form-group w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="reset-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           New password
         </label>
@@ -406,8 +399,7 @@ exports[`ResetPasswordPage show spinner component during token validation 1`] = 
         className="form-group w-100"
       >
         <label
-          className="pt-10 focus-out form-label"
-          htmlFor="confirm-password-input"
+          className="pgn__form-label pt-10 focus-out"
         >
           Confirm password
         </label>


### PR DESCRIPTION
Added back compatibility for optional fields by updating them to new paragon components, these can be used if we decide to enable optional fields in future.
<img width="554" alt="Screenshot 2021-04-09 at 5 43 42 PM" src="https://user-images.githubusercontent.com/40633976/114182177-c3253000-995b-11eb-8f13-bbf4e66900a8.png">

#### Changes
- updated paragon package
- updated optional fields to use new paragon components
- some tests needed fixing after updating to new paragon component