### PR TITLE
Fix form padding and margins

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -16,6 +16,7 @@ $apple-focus-black: $apple-black;
 $accent-a-light: #c9f2f5;
 
 .main-content {
+  @extend .pt-4;
   min-width: 464px !important;
 }
 
@@ -353,6 +354,7 @@ select.form-control {
 
   .main-content {
     min-width: 100vw !important;
+    padding: 1.5rem !important;
   }
 }
 

--- a/src/common-components/LargeScreenRightLayout.jsx
+++ b/src/common-components/LargeScreenRightLayout.jsx
@@ -7,8 +7,8 @@ const LargeScreenRightLayout = (props) => {
   const { children } = props;
 
   return (
-    <Col xs={6} className="min-vh-100 d-flex justify-content-center mt-5">
-      { children }
+    <Col xs={6} className="min-vh-100 d-flex justify-content-center">
+      <div className="mt-5">{ children }</div>
     </Col>
   );
 };

--- a/src/common-components/Logistration.jsx
+++ b/src/common-components/Logistration.jsx
@@ -23,7 +23,7 @@ const Logistration = (props) => {
           {intl.formatMessage(messages['logistration.login'])}
         </Link>
       </span>
-      <div id="main-content" className="p-2 main-content">
+      <div id="main-content" className="main-content">
         {selectedPage === LOGIN_PAGE ? <LoginPage /> : <RegistrationPage />}
       </div>
     </div>

--- a/src/common-components/MediumScreenLayout.jsx
+++ b/src/common-components/MediumScreenLayout.jsx
@@ -9,8 +9,8 @@ const MediumScreenLayout = (props) => {
   return (
     <>
       <MediumScreenHeader />
-      <div className="mt-5 d-flex align-items-center justify-content-center">
-        { children }
+      <div className="d-flex align-items-center justify-content-center">
+        <div className="mt-5">{ children }</div>
       </div>
     </>
   );


### PR DESCRIPTION
The margin added to `LargeScreenRightLayout` was making the page "scrollable". This commit fixes that issue and also updated the padding for mobile view to match the designs.
<img width="414" alt="Screenshot 2021-04-22 at 4 04 24 PM" src="https://user-images.githubusercontent.com/40633976/115704199-7fcbb800-a384-11eb-8313-ebfa8da39b67.png">
