### PR TITLE
handle register page form submission

### DIFF
--- a/src/common-components/FormGroup.jsx
+++ b/src/common-components/FormGroup.jsx
@@ -34,7 +34,7 @@ const FormGroup = (props) => {
       </Form.Control>
       <TransitionReplace>
         {hasFocus && props.helpText ? (
-          <Form.Control.Feedback key="help-text" className="mt-2 d-block">
+          <Form.Control.Feedback key="help-text" className="d-block">
             {props.helpText.map((message, index) => (
               <span key={`help-text-${index.toString()}`}>
                 {message}
@@ -45,7 +45,7 @@ const FormGroup = (props) => {
         ) : <div key="empty" />}
       </TransitionReplace>
       {props.errorMessage !== '' && (
-        <Form.Control.Feedback key="error" feedback-for={props.name} className="data-hj-suppress" type="invalid">{props.errorMessage}</Form.Control.Feedback>
+        <Form.Control.Feedback key="error" feedback-for={props.name} type="invalid">{props.errorMessage}</Form.Control.Feedback>
       )}
       {props.children}
     </Form.Group>

--- a/src/common-components/ThirdPartyAuthAlert.jsx
+++ b/src/common-components/ThirdPartyAuthAlert.jsx
@@ -1,35 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Alert } from '@edx/paragon';
+
+import messages from './messages';
 import { LOGIN_PAGE, REGISTER_PAGE } from '../data/constants';
 
 const ThirdPartyAuthAlert = (props) => {
-  const { currentProvider, referrer, platformName } = props;
+  const { currentProvider, intl, referrer } = props;
+  const platformName = getConfig().SITE_NAME;
   let message;
 
   if (referrer === LOGIN_PAGE) {
-    message = (
-      <FormattedMessage
-        id="login.third.party.auth.account.not.linked.message"
-        defaultMessage="You have successfully signed into {currentProvider}, but your {currentProvider} account does not have a linked {platformName} account. To link your accounts, sign in now using your {platformName} password."
-        description="Message that appears on login page if user has successfully authenticated with TPA but no associated platform account exists"
-        values={{ currentProvider, platformName }}
-      />
-    );
+    message = intl.formatMessage(messages['login.third.party.auth.account.not.linked'], { currentProvider, platformName });
   } else {
-    message = (
-      <FormattedMessage
-        id="register.third.party.auth.account.not.linked.message"
-        defaultMessage="You've successfully signed into {currentProvider}. We just need a little more information before you start learning with {platformName}."
-        description="Message that appears on register page if user has successfully authenticated with TPA but no associated platform account exists"
-        values={{ currentProvider, platformName }}
-      />
-    );
+    message = intl.formatMessage(messages['register.third.party.auth.account.not.linked'], { currentProvider, platformName });
   }
 
-  return <Alert id="tpa-alert" className={referrer === REGISTER_PAGE ? 'alert-success mt-n2' : 'alert-warning mt-n2'}>{ message }</Alert>;
+  return (
+    <Alert id="tpa-alert" className={referrer === REGISTER_PAGE ? 'alert-success mt-n2' : 'alert-warning mt-n2'}>
+      {referrer === REGISTER_PAGE ? (
+        <Alert.Heading>{intl.formatMessage(messages['tpa.alert.heading'])}</Alert.Heading>
+      ) : null}
+      <p>{ message }</p>
+    </Alert>
+  );
 };
 
 ThirdPartyAuthAlert.defaultProps = {
@@ -38,8 +35,8 @@ ThirdPartyAuthAlert.defaultProps = {
 
 ThirdPartyAuthAlert.propTypes = {
   currentProvider: PropTypes.string.isRequired,
-  platformName: PropTypes.string.isRequired,
+  intl: intlShape.isRequired,
   referrer: PropTypes.string,
 };
 
-export default ThirdPartyAuthAlert;
+export default injectIntl(ThirdPartyAuthAlert);

--- a/src/common-components/messages.jsx
+++ b/src/common-components/messages.jsx
@@ -107,6 +107,27 @@ const messages = defineMessages({
     defaultMessage: '8 Characters',
     description: 'password requirement to have a minimum of 8 characters',
   },
+  // third party auth
+  'tpa.alert.heading': {
+    id: 'tpa.alert.heading',
+    defaultMessage: 'Almost done',
+    description: 'Success alert heading after user has successfully signed in with social auth',
+  },
+  'login.third.party.auth.account.not.linked': {
+    id: 'login.third.party.auth.account.not.linked',
+    defaultMessage: 'You have successfully signed into {currentProvider}, but your {currentProvider} '
+                    + 'account does not have a linked {platformName} account. To link your accounts, '
+                    + 'sign in now using your {platformName} password.',
+    description: 'Message that appears on login page if user has successfully authenticated with social '
+                  + 'auth but no associated platform account exists',
+  },
+  'register.third.party.auth.account.not.linked': {
+    id: 'register.third.party.auth.account.not.linked',
+    defaultMessage: 'You\'ve successfully signed into {currentProvider}! We just need a little more information '
+                    + 'before you start learning with {platformName}.',
+    description: 'Message that appears on register page if user has successfully authenticated with TPA '
+                  + 'but no associated platform account exists',
+  },
 });
 
 export default messages;

--- a/src/common-components/tests/Logistration.test.jsx
+++ b/src/common-components/tests/Logistration.test.jsx
@@ -40,7 +40,7 @@ describe('Logistration', () => {
     store = mockStore({
       register: {
         registrationResult: { success: false, redirectUrl: '' },
-        registrationError: null,
+        registrationError: {},
       },
       commonComponents: {
         thirdPartyAuthApiStatus: null,

--- a/src/common-components/tests/ThirdPartyAuthAlert.test.jsx
+++ b/src/common-components/tests/ThirdPartyAuthAlert.test.jsx
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import ThirdPartyAuthAlert from '../ThirdPartyAuthAlert';
+import { REGISTER_PAGE } from '../../data/constants';
 
 describe('ThirdPartyAuthAlert', () => {
   let props = {};
@@ -26,7 +27,7 @@ describe('ThirdPartyAuthAlert', () => {
   it('should match register page third party auth alert message snapshot', () => {
     props = {
       ...props,
-      referrer: 'register',
+      referrer: REGISTER_PAGE,
     };
 
     const tree = renderer.create(

--- a/src/common-components/tests/__snapshots__/ThirdPartyAuthAlert.test.jsx.snap
+++ b/src/common-components/tests/__snapshots__/ThirdPartyAuthAlert.test.jsx.snap
@@ -6,20 +6,25 @@ exports[`ThirdPartyAuthAlert should match login page third party auth alert mess
   id="tpa-alert"
   role="alert"
 >
-  <span>
+  <p>
     You have successfully signed into Google, but your Google account does not have a linked edX account. To link your accounts, sign in now using your edX password.
-  </span>
+  </p>
 </div>
 `;
 
 exports[`ThirdPartyAuthAlert should match register page third party auth alert message snapshot 1`] = `
 <div
-  className="fade alert-warning mt-n2 alert show"
+  className="fade alert-success mt-n2 alert show"
   id="tpa-alert"
   role="alert"
 >
-  <span>
-    You've successfully signed into Google. We just need a little more information before you start learning with edX.
-  </span>
+  <div
+    className="alert-heading h4"
+  >
+    Almost done
+  </div>
+  <p>
+    You've successfully signed into Google! We just need a little more information before you start learning with edX.
+  </p>
 </div>
 `;

--- a/src/login/tests/LoginPage.test.jsx
+++ b/src/login/tests/LoginPage.test.jsx
@@ -252,7 +252,7 @@ describe('LoginPage', () => {
                             + 'linked edX account. To link your accounts, sign in now using your edX password.';
 
     const loginPage = mount(reduxWrapper(<IntlLoginPage {...props} />));
-    expect(loginPage.find('#tpa-alert').find('span').text()).toEqual(expectedMessage);
+    expect(loginPage.find('#tpa-alert').find('p').text()).toEqual(expectedMessage);
   });
 
   it('should match forget password confirmation message', () => {

--- a/src/register/RegistrationFailure.jsx
+++ b/src/register/RegistrationFailure.jsx
@@ -2,83 +2,53 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Alert } from '@edx/paragon';
+import { Alert, Icon } from '@edx/paragon';
+import { Info } from '@edx/paragon/icons';
 
-import { FORBIDDEN_REQUEST, INTERNAL_SERVER_ERROR } from './data/constants';
+import { FORBIDDEN_REQUEST, INTERNAL_SERVER_ERROR, TPA_SESSION_EXPIRED } from './data/constants';
 import messages from './messages';
-import { DEFAULT_STATE, PENDING_STATE } from '../data/constants';
 
 const RegistrationFailureMessage = (props) => {
-  const errorMessage = props.errors;
-  const { errorCode } = props.errors;
-  const userErrors = [];
+  const { context, errorCode, intl } = props;
 
   useEffect(() => {
-    if (props.isSubmitted && props.submitButtonState !== PENDING_STATE) {
-      window.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
-    }
-  });
+    window.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
+  }, [errorCode]);
 
-  let serverError;
+  let errorMessage;
   switch (errorCode) {
     case INTERNAL_SERVER_ERROR:
-      serverError = (
-        <li key={INTERNAL_SERVER_ERROR} className="text-left">
-          {props.intl.formatMessage(messages['registration.request.server.error'])}
-        </li>
-      );
-     userErrors.push(serverError);
+      errorMessage = intl.formatMessage(messages['registration.request.server.error']);
      break;
     case FORBIDDEN_REQUEST:
-      userErrors.push(
-        (
-          <li key={FORBIDDEN_REQUEST} className="text-left">
-            {props.intl.formatMessage(messages['register.rate.limit.reached.message'])}
-          </li>
-        ),
-      );
+      errorMessage = intl.formatMessage(messages['registration.rate.limit.error']);
+      break;
+    case TPA_SESSION_EXPIRED:
+      errorMessage = intl.formatMessage(messages['registration.tpa.session.expired'], { provider: context.provider });
       break;
     default:
-      Object.keys(errorMessage).forEach((key) => {
-        if (key !== 'error_code') {
-          const errors = errorMessage[key];
-          const suppressionClass = ['email', 'username'].includes(key) ? 'data-hj-suppress' : '';
-          const errorList = errors.map((error) => (
-            (error.user_message) ? (
-              <li key={error} className={`text-left ${suppressionClass}`}>
-                {error.user_message}
-              </li>
-            ) : null
-          ));
-          userErrors.push(errorList);
-        }
-      });
+      errorMessage = intl.formatMessage(messages['registration.empty.form.submission.error']);
+      break;
   }
 
   return (
-    !userErrors.length ? null : (
-      <Alert id="validation-errors" variant="danger">
-        <Alert.Heading>{props.intl.formatMessage(messages['registration.request.failure.header'])}</Alert.Heading>
-        <ul>{userErrors}</ul>
-      </Alert>
-    )
+    <Alert id="validation-errors" className="mb-5" variant="danger">
+      <Icon src={Info} className="alert-icon" />
+      <Alert.Heading>{props.intl.formatMessage(messages['registration.request.failure.header'])}</Alert.Heading>
+      <p>{errorMessage}</p>
+    </Alert>
   );
 };
 
 RegistrationFailureMessage.defaultProps = {
-  errors: '',
-  submitButtonState: DEFAULT_STATE,
-  isSubmitted: false,
+  context: {},
 };
 
 RegistrationFailureMessage.propTypes = {
-  errors: PropTypes.shape({
-    email: PropTypes.array,
-    username: PropTypes.array,
-    errorCode: PropTypes.string,
+  context: PropTypes.shape({
+    provider: PropTypes.string,
   }),
-  submitButtonState: PropTypes.string,
-  isSubmitted: PropTypes.bool,
+  errorCode: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
 };
 

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -18,11 +18,13 @@ import {
 import { ExpandMore } from '@edx/paragon/icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { registerNewUser, fetchRealtimeValidations } from './data/actions';
-import { registrationRequestSelector, validationsSelector } from './data/selectors';
+import { registerNewUser, resetRegistrationForm, fetchRealtimeValidations } from './data/actions';
+import { FORM_SUBMISSION_ERROR } from './data/constants';
+import { registrationErrorSelector, registrationRequestSelector, validationsSelector } from './data/selectors';
 import messages from './messages';
 import OptionalFields from './OptionalFields';
 import RegistrationFailure from './RegistrationFailure';
+import UsernameField from './UsernameField';
 
 import {
   RedirectLogistration, SocialAuthProviders, ThirdPartyAuthAlert, RenderInstitutionButton,
@@ -32,38 +34,27 @@ import { getThirdPartyAuthContext } from '../common-components/data/actions';
 import { thirdPartyAuthContextSelector } from '../common-components/data/selectors';
 import EnterpriseSSO from '../common-components/EnterpriseSSO';
 import {
-  DEFAULT_STATE, PENDING_STATE, REGISTER_PAGE,
+  DEFAULT_STATE, LETTER_REGEX, NUMBER_REGEX, PENDING_STATE, REGISTER_PAGE, VALID_EMAIL_REGEX,
 } from '../data/constants';
 import {
   getTpaProvider, getTpaHint, getAllPossibleQueryParam,
 } from '../data/utils';
-import UsernameField from './UsernameField';
 
 class RegistrationPage extends React.Component {
   constructor(props, context) {
     super(props, context);
-
     sendPageEvent('login_and_registration', 'register');
-    this.intl = props.intl;
-    this.queryParams = getAllPossibleQueryParam();
-    this.tpaHint = getTpaHint();
 
     const optionalFields = getConfig().REGISTRATION_OPTIONAL_FIELDS ? getConfig().REGISTRATION_OPTIONAL_FIELDS.split(',') : [];
 
+    this.queryParams = getAllPossibleQueryParam();
+    this.tpaHint = getTpaHint();
     this.state = {
+      country: '',
       email: '',
       name: '',
-      username: '',
       password: '',
-      country: '',
-      showOptionalField: false,
-      validationAlertMessages: {
-        name: [{ user_message: '' }],
-        username: [{ user_message: '' }],
-        email: [{ user_message: '' }],
-        password: [{ user_message: '' }],
-        country: [{ user_message: '' }],
-      },
+      username: '',
       errors: {
         email: '',
         name: '',
@@ -71,15 +62,12 @@ class RegistrationPage extends React.Component {
         password: '',
         country: '',
       },
+      errorCode: null,
       institutionLogin: false,
-      formValid: false,
       optionalFields,
       optionalFieldsState: {},
+      showOptionalField: false,
       startTime: Date.now(),
-      updateFieldErrors: false,
-      updateAlertErrors: false,
-      registrationErrorsUpdated: false,
-      fieldName: '',
     };
   }
 
@@ -89,45 +77,35 @@ class RegistrationPage extends React.Component {
     if (this.tpaHint) {
       payload.tpa_hint = this.tpaHint;
     }
+    this.props.resetRegistrationForm();
     this.props.getThirdPartyAuthContext(payload);
   }
 
   shouldComponentUpdate(nextProps) {
-    if (nextProps.statusCode !== 403 && this.props.validations !== nextProps.validations) {
-      const { errors, fieldName } = this.state;
-      errors[fieldName] = nextProps.validations.validation_decisions[fieldName];
+    if (this.props.validationDecisions !== nextProps.validationDecisions) {
+      const state = { errors: { ...this.state.errors, ...nextProps.validationDecisions } };
 
-      this.setState({
-        errors,
-      });
+      if (nextProps.registrationErrorCode) {
+        state.errorCode = nextProps.registrationErrorCode;
+      }
+      this.setState({ ...state });
+      return false;
+    }
+
+    if (this.props.registrationErrorCode !== nextProps.registrationErrorCode) {
+      this.setState({ errorCode: nextProps.registrationErrorCode });
       return false;
     }
 
     if (this.props.thirdPartyAuthContext.pipelineUserDetails !== nextProps.thirdPartyAuthContext.pipelineUserDetails) {
       this.setState({
         ...nextProps.thirdPartyAuthContext.pipelineUserDetails,
+        country: nextProps.thirdPartyAuthContext.countryCode || '',
       });
       return false;
     }
 
-    if (this.props.registrationError !== nextProps.registrationError) {
-      this.setState({
-        formValid: false,
-        registrationErrorsUpdated: true,
-      });
-      return false;
-    }
-
-    if (this.state.registrationErrorsUpdated && this.props.registrationError === nextProps.registrationError) {
-      this.setState({
-        formValid: false,
-        registrationErrorsUpdated: false,
-      });
-      return false;
-    }
-
-    if (this.props.thirdPartyAuthContext.countryCode
-    && this.state.country !== nextProps.thirdPartyAuthContext.countryCode) {
+    if (this.props.thirdPartyAuthContext.countryCode !== nextProps.thirdPartyAuthContext.countryCode) {
       this.setState({
         country: nextProps.thirdPartyAuthContext.countryCode || '',
       });
@@ -172,6 +150,7 @@ class RegistrationPage extends React.Component {
       email: this.state.email,
       country: this.state.country,
       honor_code: true,
+      is_authn_mfe: true,
     };
 
     if (this.props.thirdPartyAuthContext.currentProvider) {
@@ -180,30 +159,34 @@ class RegistrationPage extends React.Component {
       payload.password = this.state.password;
     }
 
-    const postParams = getAllPossibleQueryParam();
-    payload = { ...payload, ...postParams };
+    let errors = {};
+    Object.keys(payload).forEach(key => {
+      errors = this.validateInput(key, payload[key], payload);
+    });
 
-    let finalValidation = this.state.formValid;
-    if (!this.state.formValid) {
-      Object.keys(payload).forEach(key => {
-        finalValidation = this.validateInput(key, payload[key], payload);
-      });
+    if (!this.isFormValid(errors)) {
+      this.setState({ errorCode: FORM_SUBMISSION_ERROR });
+      return;
     }
-    // Since optional fields are not validated we can add it to payload after required fields
-    // have been validated. This will save us unwanted calls to validateInput()
+
+    // Since optional fields and query params are not validated we can add it to payload after
+    // required fields have been validated. This will save us unwanted calls to validateInput()
+    payload = { ...payload, ...this.queryParams };
     this.state.optionalFields.forEach((key) => {
       if (this.state.optionalFieldsState[key]) {
         payload[snakeCase(key)] = this.state.optionalFieldsState[key];
       }
     });
-    if (finalValidation) {
-      payload.totalRegistrationTime = totalRegistrationTime;
-      this.props.registerNewUser(payload);
-    }
+
+    payload.totalRegistrationTime = totalRegistrationTime;
+    this.props.registerNewUser(payload);
   }
 
   handleOnBlur = (e) => {
+    const { name, value } = e.target;
     const payload = {
+      is_authn_mfe: true,
+      form_field_key: name,
       email: this.state.email,
       username: this.state.username,
       password: this.state.password,
@@ -211,29 +194,18 @@ class RegistrationPage extends React.Component {
       honor_code: true,
       country: this.state.country,
     };
-    const { name, value } = e.target;
-    this.setState({
-      fieldName: e.target.name,
-      updateFieldErrors: false,
-      updateAlertErrors: false,
-    }, () => {
-      this.validateInput(name, value, payload, false);
-    });
+    this.validateInput(name, value, payload);
   }
 
   handleOnChange = (e) => {
     if (e.target.name === 'optionalFields') {
+      sendTrackEvent('edx.bi.user.register.optional_fields_selected', {});
       this.setState({
         showOptionalField: e.target.checked,
-        updateAlertErrors: false,
-        updateFieldErrors: false,
       });
-      sendTrackEvent('edx.bi.user.register.optional_fields_selected', {});
     } else if (!(e.target.name === 'username' && e.target.value.length > 30)) {
       this.setState({
         [e.target.name]: e.target.value,
-        updateFieldErrors: false,
-        updateAlertErrors: false,
       });
     }
   }
@@ -241,53 +213,32 @@ class RegistrationPage extends React.Component {
   handleSuggestionClick = (suggestion) => {
     const fieldName = 'username';
     const payload = {
+      is_authn_mfe: true,
       username: suggestion,
     };
     this.setState({
       ...payload,
-      fieldName,
-      updateFieldErrors: false,
-      updateAlertErrors: false,
     }, () => {
-      this.validateInput(fieldName, suggestion, payload, false);
+      this.validateInput(fieldName, suggestion, payload);
     });
   }
 
-  checkNoAlertErrors(validations) {
-    const keyValidList = Object.entries(validations).map(([key]) => {
-      const validation = validations[key][0];
-      return !validation.user_message;
-    });
-    return keyValidList.every((current) => current === true);
-  }
-
-  checkNoFieldErrors(validations) {
+  isFormValid(validations) {
     const keyValidList = Object.entries(validations).map(([key]) => !validations[key]);
     return keyValidList.every((current) => current === true);
   }
 
-  validateInput(inputName, value, payload, updateAlertMessage = true) {
-    const {
-      errors,
-    } = this.state;
-    const {
-      intl,
-      statusCode,
-    } = this.props;
+  validateInput(fieldName, value, payload) {
+    const { errors } = this.state;
+    const { intl, statusCode } = this.props;
 
-    let {
-      formValid,
-      updateFieldErrors,
-      updateAlertErrors,
-    } = this.state;
-    switch (inputName) {
+    const emailRegex = new RegExp(VALID_EMAIL_REGEX, 'i');
+    switch (fieldName) {
       case 'email':
-        if (value.length < 1) {
-          errors.email = intl.formatMessage(messages['email.validation.message']);
-        } else if (value.length <= 2) {
-          errors.email = intl.formatMessage(messages['email.ratelimit.less.chars.validation.message']);
-        } else if (!value.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i)) {
-          errors.email = intl.formatMessage(messages['email.ratelimit.incorrect.format.validation.message']);
+        if (!value) {
+          errors.email = intl.formatMessage(messages['empty.email.field.error']);
+        } else if (value.length <= 2 || !emailRegex.test(value)) {
+          errors.email = intl.formatMessage(messages['email.invalid.format.error']);
         } else if (payload && statusCode !== 403) {
           this.props.fetchRealtimeValidations(payload);
         } else {
@@ -295,17 +246,15 @@ class RegistrationPage extends React.Component {
         }
         break;
       case 'name':
-        if (value.length < 1) {
-          errors.name = intl.formatMessage(messages['fullname.validation.message']);
+        if (!value) {
+          errors.name = intl.formatMessage(messages['empty.name.field.error']);
         } else {
           errors.name = '';
         }
         break;
       case 'username':
-        if (value.length < 1) {
+        if (!value || value.length <= 1 || value.length > 30) {
           errors.username = intl.formatMessage(messages['username.validation.message']);
-        } else if (value.length <= 1 || value.length > 30) {
-          errors.username = intl.formatMessage(messages['username.ratelimit.less.chars.message']);
         } else if (!value.match(/^[a-zA-Z0-9_-]*$/i)) {
           errors.username = intl.formatMessage(messages['username.format.validation.message']);
         } else if (payload && statusCode !== 403) {
@@ -315,14 +264,8 @@ class RegistrationPage extends React.Component {
         }
         break;
       case 'password':
-        if (value.length < 1) {
-          errors.password = intl.formatMessage(messages['register.page.password.validation.message']);
-        } else if (value.length < 8) {
-          errors.password = intl.formatMessage(messages['email.ratelimit.password.validation.message']);
-        } else if (!value.match(/.*[0-9].*/i)) {
-          errors.password = intl.formatMessage(messages['username.number.validation.message']);
-        } else if (!value.match(/.*[a-zA-Z].*/i)) {
-          errors.password = intl.formatMessage(messages['username.character.validation.message']);
+        if (!value || !LETTER_REGEX.test(value) || !NUMBER_REGEX.test(value) || value.length < 8) {
+          errors.password = intl.formatMessage(messages['password.validation.message']);
         } else if (payload && statusCode !== 403) {
           this.props.fetchRealtimeValidations(payload);
         } else {
@@ -331,7 +274,7 @@ class RegistrationPage extends React.Component {
         break;
       case 'country':
         if (!value) {
-          errors.country = intl.formatMessage(messages['country.validation.message']);
+          errors.country = intl.formatMessage(messages['empty.country.field.error']);
         } else {
           errors.country = '';
         }
@@ -340,73 +283,8 @@ class RegistrationPage extends React.Component {
         break;
     }
 
-    if (updateAlertMessage) {
-      updateFieldErrors = true;
-      updateAlertErrors = true;
-      formValid = this.checkNoFieldErrors(errors);
-    }
-    this.setState({
-      formValid,
-      updateFieldErrors,
-      updateAlertErrors,
-      errors,
-    });
-    return formValid;
-  }
-
-  updateFieldErrors(registrationError) {
-    const {
-      errors,
-    } = this.state;
-    Object.entries(registrationError).map(([key]) => {
-      if (registrationError[key]) {
-        errors[key] = registrationError[key][0].user_message;
-      }
-      return errors;
-    });
-  }
-
-  updateValidationAlertMessages() {
-    const {
-      errors,
-      validationAlertMessages,
-    } = this.state;
-    Object.entries(errors).map(([key, value]) => {
-      if (validationAlertMessages[key]) {
-        validationAlertMessages[key][0].user_message = value;
-      }
-      return validationAlertMessages;
-    });
-  }
-
-  renderErrors() {
-    let errorsObject = null;
-    let { registrationErrorsUpdated } = this.state;
-    const {
-      updateAlertErrors,
-      updateFieldErrors,
-      validationAlertMessages,
-    } = this.state;
-    const { registrationError, submitState } = this.props;
-    if (registrationError && registrationErrorsUpdated) {
-      if (updateFieldErrors && submitState !== PENDING_STATE) {
-        this.updateFieldErrors(registrationError);
-      }
-      registrationErrorsUpdated = false;
-      errorsObject = registrationError;
-    } else {
-      if (updateAlertErrors && submitState !== PENDING_STATE) {
-        this.updateValidationAlertMessages();
-      }
-      errorsObject = !this.checkNoAlertErrors(validationAlertMessages) ? validationAlertMessages : {};
-    }
-    return (
-      <RegistrationFailure
-        errors={errorsObject}
-        isSubmitted={updateAlertErrors}
-        submitButtonState={submitState}
-      />
-    );
+    this.setState({ errors });
+    return errors;
   }
 
   renderThirdPartyAuth(providers, secondaryProviders, currentProvider, thirdPartyAuthApiStatus, intl) {
@@ -461,13 +339,18 @@ class RegistrationPage extends React.Component {
           finishAuthUrl={finishAuthUrl}
         />
         <div className="mw-xs mt-3">
-          {this.renderErrors()}
+          {this.state.errorCode ? (
+            <RegistrationFailure errorCode={this.state.errorCode} context={{ provider: currentProvider }} />
+          ) : null}
           {currentProvider && (
-            <ThirdPartyAuthAlert
-              currentProvider={currentProvider}
-              platformName={this.props.thirdPartyAuthContext.platformName}
-              referrer={REGISTER_PAGE}
-            />
+            <>
+              <ThirdPartyAuthAlert
+                currentProvider={currentProvider}
+                platformName={this.props.thirdPartyAuthContext.platformName}
+                referrer={REGISTER_PAGE}
+              />
+              <h4 className="mt-4 mb-4">{intl.formatMessage(messages['registration.using.tpa.form.heading'])}</h4>
+            </>
           )}
           <Form>
             <FormGroup
@@ -556,7 +439,7 @@ class RegistrationPage extends React.Component {
             <StatefulButton
               type="submit"
               variant="brand"
-              className="register-button-width mt-4"
+              className="register-button-width mt-4 mb-4"
               state={submitState}
               labels={{
                 default: intl.formatMessage(messages['create.account.button']),
@@ -570,7 +453,7 @@ class RegistrationPage extends React.Component {
             />
             {(providers.length || secondaryProviders.length || thirdPartyAuthApiStatus === PENDING_STATE)
               && !currentProvider ? (
-                <div className="mt-4 mb-3 h4">
+                <div className="mb-3 h4">
                   {intl.formatMessage(messages['registration.other.options.heading'])}
                 </div>
               ) : null}
@@ -626,7 +509,7 @@ class RegistrationPage extends React.Component {
 RegistrationPage.defaultProps = {
   registrationResult: null,
   registerNewUser: null,
-  registrationError: null,
+  registrationErrorCode: null,
   submitState: DEFAULT_STATE,
   thirdPartyAuthApiStatus: 'pending',
   thirdPartyAuthContext: {
@@ -637,7 +520,7 @@ RegistrationPage.defaultProps = {
     secondaryProviders: [],
     pipelineUserDetails: null,
   },
-  validations: null,
+  validationDecisions: null,
   statusCode: null,
 };
 
@@ -645,17 +528,12 @@ RegistrationPage.propTypes = {
   intl: intlShape.isRequired,
   getThirdPartyAuthContext: PropTypes.func.isRequired,
   registerNewUser: PropTypes.func,
+  resetRegistrationForm: PropTypes.func.isRequired,
   registrationResult: PropTypes.shape({
     redirectUrl: PropTypes.string,
     success: PropTypes.bool,
   }),
-  registrationError: PropTypes.shape({
-    email: PropTypes.array,
-    username: PropTypes.array,
-    country: PropTypes.array,
-    password: PropTypes.array,
-    name: PropTypes.array,
-  }),
+  registrationErrorCode: PropTypes.string,
   submitState: PropTypes.string,
   thirdPartyAuthApiStatus: PropTypes.string,
   thirdPartyAuthContext: PropTypes.shape({
@@ -674,15 +552,12 @@ RegistrationPage.propTypes = {
     }),
   }),
   fetchRealtimeValidations: PropTypes.func.isRequired,
-  validations: PropTypes.shape({
-    validation_decisions: PropTypes.shape({
-      country: PropTypes.string,
-      email: PropTypes.string,
-      name: PropTypes.string,
-      password: PropTypes.string,
-      username: PropTypes.string,
-      fieldName: PropTypes.string,
-    }),
+  validationDecisions: PropTypes.shape({
+    country: PropTypes.string,
+    email: PropTypes.string,
+    name: PropTypes.string,
+    password: PropTypes.string,
+    username: PropTypes.string,
   }),
   statusCode: PropTypes.number,
 };
@@ -691,12 +566,12 @@ const mapStateToProps = state => {
   const registrationResult = registrationRequestSelector(state);
   const thirdPartyAuthContext = thirdPartyAuthContextSelector(state);
   return {
-    registrationError: state.register.registrationError,
+    registrationErrorCode: registrationErrorSelector(state),
     submitState: state.register.submitState,
     thirdPartyAuthApiStatus: state.commonComponents.thirdPartyAuthApiStatus,
     registrationResult,
     thirdPartyAuthContext,
-    validations: validationsSelector(state),
+    validationDecisions: validationsSelector(state),
     statusCode: state.register.statusCode,
   };
 };
@@ -707,5 +582,6 @@ export default connect(
     getThirdPartyAuthContext,
     fetchRealtimeValidations,
     registerNewUser,
+    resetRegistrationForm,
   },
 )(injectIntl(RegistrationPage));

--- a/src/register/UsernameField.jsx
+++ b/src/register/UsernameField.jsx
@@ -10,11 +10,11 @@ import { FormGroup } from '../common-components';
 import messages from './messages';
 
 const UsernameField = (props) => {
-  const { intl, usernameSuggestions } = props;
+  const { intl, usernameSuggestions, errorMessage } = props;
 
   return (
     <FormGroup {...props}>
-      {usernameSuggestions.length > 0 ? (
+      {usernameSuggestions.length > 0 && errorMessage ? (
         <div>
           <span className="text-gray mr-2">{intl.formatMessage(messages['registration.username.suggestion.label'])}</span>
           {usernameSuggestions.map((username, index) => (
@@ -37,11 +37,13 @@ const UsernameField = (props) => {
 UsernameField.defaultProps = {
   usernameSuggestions: [],
   handleSuggestionClick: () => {},
+  errorMessage: '',
 };
 
 UsernameField.propTypes = {
   usernameSuggestions: PropTypes.arrayOf(string),
   handleSuggestionClick: PropTypes.func,
+  errorMessage: PropTypes.string,
   intl: intlShape.isRequired,
   name: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,

--- a/src/register/data/actions.js
+++ b/src/register/data/actions.js
@@ -2,6 +2,12 @@ import { AsyncActionType } from '../../data/utils';
 
 export const REGISTER_NEW_USER = new AsyncActionType('REGISTRATION', 'REGISTER_NEW_USER');
 export const REGISTER_FORM_VALIDATIONS = new AsyncActionType('REGISTRATION', 'GET_FORM_VALIDATIONS');
+export const REGISTRATION_FORM = new AsyncActionType('REGISTRATION', 'REGISTRATION_FORM');
+
+// Reset Form
+export const resetRegistrationForm = () => ({
+  type: REGISTRATION_FORM.RESET,
+});
 
 // Register
 export const registerNewUser = registrationInfo => ({
@@ -21,7 +27,7 @@ export const registerNewUserSuccess = (redirectUrl, success) => ({
 
 export const registerNewUserFailure = (error) => ({
   type: REGISTER_NEW_USER.FAILURE,
-  payload: { error },
+  payload: { ...error },
 });
 
 // Realtime Field validations
@@ -39,7 +45,6 @@ export const fetchRealtimeValidationsSuccess = (validations) => ({
   payload: { validations },
 });
 
-export const fetchRealtimeValidationsFailure = (error, statusCode) => ({
+export const fetchRealtimeValidationsFailure = () => ({
   type: REGISTER_FORM_VALIDATIONS.FAILURE,
-  payload: { error, statusCode },
 });

--- a/src/register/data/constants.js
+++ b/src/register/data/constants.js
@@ -1,6 +1,8 @@
 // Registration Error Codes
-export const INTERNAL_SERVER_ERROR = 'internal-server-error';
 export const FORBIDDEN_REQUEST = 'forbidden-request';
+export const FORM_SUBMISSION_ERROR = 'form-submission-error';
+export const INTERNAL_SERVER_ERROR = 'internal-server-error';
+export const TPA_SESSION_EXPIRED = 'tpa-session-expired';
 
 export const YEAR_OF_BIRTH_OPTIONS = (() => {
   const currentYear = new Date().getFullYear();
@@ -28,3 +30,6 @@ export const EDUCATION_LEVELS = [
 ];
 
 export const GENDER_OPTIONS = ['', 'f', 'm', 'o'];
+
+// Other constants
+export const FORM_FIELDS = ['name', 'email', 'password', 'username', 'country'];

--- a/src/register/data/reducers.js
+++ b/src/register/data/reducers.js
@@ -1,9 +1,9 @@
-import { REGISTER_NEW_USER, REGISTER_FORM_VALIDATIONS } from './actions';
+import { REGISTRATION_FORM, REGISTER_NEW_USER, REGISTER_FORM_VALIDATIONS } from './actions';
 
 import { DEFAULT_STATE, PENDING_STATE } from '../../data/constants';
 
 export const defaultState = {
-  registrationError: null,
+  registrationError: {},
   registrationResult: {},
   formData: null,
   validations: null,
@@ -12,10 +12,15 @@ export const defaultState = {
 
 const reducer = (state = defaultState, action) => {
   switch (action.type) {
+    case REGISTRATION_FORM.RESET:
+      return {
+        ...defaultState,
+      };
     case REGISTER_NEW_USER.BEGIN:
       return {
         ...state,
         submitState: PENDING_STATE,
+        registrationError: {},
       };
     case REGISTER_NEW_USER.SUCCESS:
       return {
@@ -25,8 +30,9 @@ const reducer = (state = defaultState, action) => {
     case REGISTER_NEW_USER.FAILURE:
       return {
         ...state,
-        registrationError: action.payload.error,
+        registrationError: { ...action.payload },
         submitState: DEFAULT_STATE,
+        validations: null,
       };
     case REGISTER_FORM_VALIDATIONS.BEGIN:
       return {
@@ -40,8 +46,8 @@ const reducer = (state = defaultState, action) => {
     case REGISTER_FORM_VALIDATIONS.FAILURE:
       return {
         ...state,
-        validations: action.payload.error,
-        statusCode: action.payload.statusCode,
+        statusCode: 403,
+        validations: null,
       };
     default:
       return state;

--- a/src/register/data/sagas.js
+++ b/src/register/data/sagas.js
@@ -30,11 +30,8 @@ export function* handleNewUserRegistration(action) {
       success,
     ));
   } catch (e) {
-    const statusCodes = [400, 409];
+    const statusCodes = [400, 403, 409];
     if (e.response && statusCodes.includes(e.response.status)) {
-      yield put(registerNewUserFailure(e.response.data));
-      logInfo(e);
-    } else if (e.response.status === 403) {
       yield put(registerNewUserFailure(camelCaseObject(e.response.data)));
       logInfo(e);
     } else {
@@ -49,13 +46,10 @@ export function* fetchRealtimeValidations(action) {
     yield put(fetchRealtimeValidationsBegin());
     const { fieldValidations } = yield call(getFieldsValidations, action.payload.formPayload);
 
-    yield put(fetchRealtimeValidationsSuccess(
-      fieldValidations,
-    ));
+    yield put(fetchRealtimeValidationsSuccess(camelCaseObject(fieldValidations)));
   } catch (e) {
-    const statusCodes = [403];
-    if (e.response && statusCodes.includes(e.response.status)) {
-      yield put(fetchRealtimeValidationsFailure(e.response.data, e.response.status));
+    if (e.response && e.response.status === 403) {
+      yield put(fetchRealtimeValidationsFailure());
       logInfo(e);
     } else {
       logError(e);

--- a/src/register/data/selectors.js
+++ b/src/register/data/selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { FORM_FIELDS } from './constants';
 
 export const storeName = 'register';
 
@@ -11,22 +12,39 @@ export const registrationRequestSelector = createSelector(
 
 export const registrationErrorSelector = createSelector(
   registerSelector,
-  register => register.registrationError,
+  register => register.registrationError.errorCode,
 );
 
 export const validationsSelector = createSelector(
   registerSelector,
-  register => register.validations,
+  (register) => {
+    const { registrationError, validations } = register;
+
+    if (validations) {
+      return validations.validationDecisions;
+    }
+
+    if (Object.keys(registrationError).length > 0) {
+      const validationDecisions = {};
+      FORM_FIELDS.forEach(field => {
+        validationDecisions[field] = registrationError[field] ? registrationError[field][0].userMessage : '';
+      });
+
+      return validationDecisions;
+    }
+
+    return null;
+  },
 );
 
 export const usernameSuggestionsSelector = createSelector(
-  validationsSelector,
-  registrationErrorSelector,
-  (validations, registrationResult) => {
-    let usernameSuggestions = validations && validations.username_suggestions ? validations.username_suggestions : [];
+  registerSelector,
+  (register) => {
+    const { registrationError, validations } = register;
+    let usernameSuggestions = validations && validations.usernameSuggestions ? validations.usernameSuggestions : [];
     if (usernameSuggestions.length === 0) {
       usernameSuggestions = (
-        registrationResult && registrationResult.username_suggestions ? registrationResult.username_suggestions : []
+        registrationError && registrationError.usernameSuggestions ? registrationError.usernameSuggestions : []
       );
     }
 

--- a/src/register/data/service.js
+++ b/src/register/data/service.js
@@ -10,7 +10,7 @@ export async function registerRequest(registrationInformation) {
 
   const { data } = await getAuthenticatedHttpClient()
     .post(
-      `${getConfig().LMS_BASE_URL}/user_api/v2/account/registration/`,
+      `${getConfig().LMS_BASE_URL}/api/user/v2/account/registration/`,
       querystring.stringify(registrationInformation),
       requestConfig,
     )

--- a/src/register/data/tests/sagas.test.js
+++ b/src/register/data/tests/sagas.test.js
@@ -31,7 +31,7 @@ describe('fetchRealtimeValidations', () => {
   });
 
   const data = {
-    validation_decisions: {
+    validationDecisions: {
       username: 'Username must be between 2 and 30 characters long.',
     },
   };

--- a/src/register/messages.jsx
+++ b/src/register/messages.jsx
@@ -48,16 +48,23 @@ const messages = defineMessages({
     defaultMessage: 'For account activation and important updates',
     description: 'Help text for email field on registration page',
   },
+  // Form buttons
   'create.account.button': {
     id: 'create.account.button',
     defaultMessage: 'Create an account',
     description: 'Button label that appears on register page',
+  },
+  'create.an.account.btn.pending.state': {
+    id: 'create.an.account.btn.pending.state',
+    defaultMessage: 'Loading',
+    description: 'Title of icon that appears when button is in pending state',
   },
   'registration.other.options.heading': {
     id: 'registration.other.options.heading',
     defaultMessage: 'Or register with:',
     description: 'A message that appears above third party auth providers i.e saml, google, facebook etc',
   },
+  // Institution login
   'register.institution.login.button': {
     id: 'register.institution.login.button',
     defaultMessage: 'Use my institution/campus credentials',
@@ -73,91 +80,77 @@ const messages = defineMessages({
     defaultMessage: 'Create an account',
     description: 'Message on button to return to register page',
   },
-  'create.an.account.btn.pending.state': {
-    id: 'create.an.account.btn.pending.state',
-    defaultMessage: 'Loading',
-    description: 'Title of icon that appears when button is in pending state',
+  // Validation messages
+  'empty.name.field.error': {
+    id: 'empty.name.field.error',
+    defaultMessage: 'Enter your full name',
+    description: 'Error message for empty fullname field',
   },
-  'register.rate.limit.reached.message': {
-    id: 'register.rate.limit.reached.message',
-    defaultMessage: 'Too many failed registration attempts. Try again later.',
-    description: 'Error message that appears when an anonymous user has made too many failed registration attempts',
+  'empty.email.field.error': {
+    id: 'empty.email.field.error',
+    defaultMessage: 'Enter your email',
+    description: 'Error message for empty email field',
   },
-  'email.validation.message': {
-    id: 'email.validation.message',
-    defaultMessage: 'Please enter your email.',
-    description: 'Validation message that appears when email address is empty',
+  'empty.country.field.error': {
+    id: 'empty.country.field.error',
+    defaultMessage: 'Select your country or region of residence',
+    description: 'Error message when no country/region is selected',
+  },
+  'email.invalid.format.error': {
+    id: 'email.invalid.format.error',
+    defaultMessage: 'Enter a valid email address',
+    description: 'Validation error for invalid email address',
   },
   'email.ratelimit.less.chars.validation.message': {
     id: 'email.ratelimit.less.chars.validation.message',
     defaultMessage: 'Email must have 3 characters.',
     description: 'Validation message that appears when email address is less than 3 characters',
   },
-  'email.ratelimit.incorrect.format.validation.message': {
-    id: 'email.ratelimit.incorrect.format.validation.message',
-    defaultMessage: 'The email address you provided isn\'t formatted correctly.',
-    description: 'Validation message that appears when email address is not formatted correctly with no backend validations available.',
-  },
-  'email.ratelimit.password.validation.message': {
-    id: 'email.ratelimit.password.validation.message',
-    defaultMessage: 'Your password must contain at least 8 characters',
-    description: 'Validation message that appears when password is not formatted correctly with no backend validations available.',
-  },
-  'register.page.password.validation.message': {
-    id: 'register.page.password.validation.message',
-    defaultMessage: 'Please enter your password.',
-    description: 'Validation message that appears when password is non compliant with edX requirement',
-  },
-  'fullname.validation.message': {
-    id: 'fullname.validation.message',
-    defaultMessage: 'Please enter your full name.',
-    description: 'Validation message that appears when fullname is empty',
-  },
-
   'username.validation.message': {
     id: 'username.validation.message',
-    defaultMessage: 'Please enter your public username.',
-    description: 'Validation message that appears when username is invalid',
+    defaultMessage: 'Username must be between 2 and 30 characters',
+    description: 'Error message for empty username field',
+  },
+  'password.validation.message': {
+    id: 'password.validation.message',
+    defaultMessage: 'Password criteria has not been met',
+    description: 'Error message for empty or invalid password',
   },
   'username.format.validation.message': {
     id: 'username.format.validation.message',
     defaultMessage: 'Usernames can only contain letters (A-Z, a-z), numerals (0-9), underscores (_), and hyphens (-).',
     description: 'Validation message that appears when username format is invalid',
   },
-  'username.character.validation.message': {
-    id: 'username.character.validation.message',
-    defaultMessage: 'Your password must contain at least 1 letter.',
-    description: 'Validation message that appears when password does not contain letter',
-  },
-  'username.number.validation.message': {
-    id: 'username.number.validation.message',
-    defaultMessage: 'Your password must contain at least 1 number.',
-    description: 'Validation message that appears when password does not contain number',
-  },
-  'username.ratelimit.less.chars.message': {
-    id: 'username.ratelimit.less.chars.message',
-    defaultMessage: 'Public username must have atleast 2 characters.',
-    description: 'Validation message that appears when username is less than 2 characters and with no backend validations available.',
-  },
-  'country.validation.message': {
-    id: 'country.validation.message',
-    defaultMessage: 'Select your country or region of residence.',
-    description: 'Validation message that appears when country is not selected',
-  },
   'support.education.research': {
     id: 'support.education.research',
     defaultMessage: 'Support education research by providing additional information. (Optional)',
     description: 'Text for a checkbox to ask user for if they are willing to provide extra information for education research',
   },
-  'registration.request.server.error': {
-    id: 'registration.request.server.error',
-    defaultMessage: 'An error has occurred. Try refreshing the page, or check your internet connection.',
-    description: 'error message on server error.',
-  },
+  // Error messages
   'registration.request.failure.header': {
     id: 'registration.request.failure.header',
     defaultMessage: 'We couldn\'t create your account.',
     description: 'error message when registration failure.',
+  },
+  'registration.empty.form.submission.error': {
+    id: 'registration.empty.form.submission.error',
+    defaultMessage: 'Please check your responses and try again.',
+    description: 'Error message that appears on top of the form when empty form is submitted',
+  },
+  'registration.request.server.error': {
+    id: 'registration.request.server.error',
+    defaultMessage: 'An error has occurred. Try refreshing the page, or check your internet connection.',
+    description: 'Error message for internal server error.',
+  },
+  'registration.rate.limit.error': {
+    id: 'registration.rate.limit.error',
+    defaultMessage: 'Too many failed registration attempts. Try again later.',
+    description: 'Error message that appears when an anonymous user has made too many failed registration attempts',
+  },
+  'registration.tpa.session.expired': {
+    id: 'registration.tpa.session.expired',
+    defaultMessage: 'Registration using {provider} has timed out.',
+    description: '',
   },
   // Terms of Service and Honor Code
   'terms.of.service.and.honor.code': {
@@ -251,10 +244,16 @@ const messages = defineMessages({
     defaultMessage: 'Other education',
     description: 'Selected by the user if they have a type of education not described by the other choices.',
   },
+  // miscellaneous strings
   'registration.username.suggestion.label': {
     id: 'registration.username.suggestion.label',
     defaultMessage: 'Available:',
     description: 'Available usernames label text.',
+  },
+  'registration.using.tpa.form.heading': {
+    id: 'registration.using.tpa.form.heading',
+    defaultMessage: 'Finish creating your account',
+    description: 'Heading that appears above form when user is trying to create account using social auth',
   },
 });
 

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -1,19 +1,22 @@
 import React from 'react';
-import { Provider } from 'react-redux';
-import renderer from 'react-test-renderer';
+
 import { mount } from 'enzyme';
 import configureStore from 'redux-mock-store';
-import { getConfig, mergeConfig } from '@edx/frontend-platform';
-import { IntlProvider, injectIntl, configure } from '@edx/frontend-platform/i18n';
-import * as analytics from '@edx/frontend-platform/analytics';
-import CookiePolicyBanner from '@edx/frontend-component-cookie-policy-banner';
+import { Provider } from 'react-redux';
+import renderer from 'react-test-renderer';
 
-import RegistrationPage from '../RegistrationPage';
-import { RenderInstitutionButton } from '../../common-components';
+import CookiePolicyBanner from '@edx/frontend-component-cookie-policy-banner';
+import { getConfig, mergeConfig } from '@edx/frontend-platform';
+import * as analytics from '@edx/frontend-platform/analytics';
+import { IntlProvider, injectIntl, configure } from '@edx/frontend-platform/i18n';
+
+import { fetchRealtimeValidations, registerNewUser, resetRegistrationForm } from '../data/actions';
+import { FORBIDDEN_REQUEST, INTERNAL_SERVER_ERROR, TPA_SESSION_EXPIRED } from '../data/constants';
 import RegistrationFailureMessage from '../RegistrationFailure';
+import RegistrationPage from '../RegistrationPage';
+
+import { RenderInstitutionButton } from '../../common-components';
 import { COMPLETE_STATE, PENDING_STATE } from '../../data/constants';
-import { fetchRealtimeValidations, registerNewUser } from '../data/actions';
-import { FORBIDDEN_REQUEST, INTERNAL_SERVER_ERROR } from '../data/constants';
 
 jest.mock('@edx/frontend-platform/analytics');
 
@@ -40,22 +43,24 @@ describe('RegistrationPage', () => {
     </IntlProvider>
   );
 
+  const thirdPartyAuthContext = {
+    platformName: 'openedX',
+    currentProvider: null,
+    finishAuthUrl: null,
+    providers: [],
+    secondaryProviders: [],
+    pipelineUserDetails: null,
+    countryCode: null,
+  };
+
   const initialState = {
     register: {
       registrationResult: { success: false, redirectUrl: '' },
-      registrationError: null,
+      registrationError: {},
     },
     commonComponents: {
       thirdPartyAuthApiStatus: null,
-      thirdPartyAuthContext: {
-        platformName: 'openedX',
-        currentProvider: null,
-        finishAuthUrl: null,
-        providers: [],
-        secondaryProviders: [],
-        pipelineUserDetails: null,
-        countryCode: null,
-      },
+      thirdPartyAuthContext,
     },
   };
 
@@ -91,11 +96,11 @@ describe('RegistrationPage', () => {
 
   describe('TestRegistrationPage', () => {
     const emptyFieldValidation = {
-      name: 'Please enter your full name.',
-      username: 'Please enter your public username.',
-      email: 'Please enter your email.',
-      password: 'Please enter your password.',
-      country: 'Select your country or region of residence.',
+      name: 'Enter your full name',
+      username: 'Username must be between 2 and 30 characters',
+      email: 'Enter your email',
+      password: 'Password criteria has not been met',
+      country: 'Select your country or region of residence',
     };
 
     const ssoProvider = {
@@ -123,6 +128,7 @@ describe('RegistrationPage', () => {
         country: 'Pakistan',
         honor_code: true,
         totalRegistrationTime: 0,
+        is_authn_mfe: true,
       };
 
       store.dispatch = jest.fn(store.dispatch);
@@ -143,6 +149,7 @@ describe('RegistrationPage', () => {
         honor_code: true,
         social_auth_provider: ssoProvider.name,
         totalRegistrationTime: 0,
+        is_authn_mfe: true,
       };
 
       store = mockStore({
@@ -183,10 +190,7 @@ describe('RegistrationPage', () => {
       expect(registrationPage.find('div[feedback-for="password"]').text()).toEqual(emptyFieldValidation.password);
       expect(registrationPage.find('div[feedback-for="country"]').text()).toEqual(emptyFieldValidation.country);
 
-      let alertBanner = 'We couldn\'t create your account.';
-      Object.keys(emptyFieldValidation).forEach(key => {
-        alertBanner += emptyFieldValidation[key];
-      });
+      const alertBanner = 'We couldn\'t create your account.Please check your responses and try again.';
 
       expect(registrationPage.find('#validation-errors').first().text()).toEqual(alertBanner);
     });
@@ -196,17 +200,12 @@ describe('RegistrationPage', () => {
 
       registrationPage.find('input#password').simulate('blur', { target: { value: 'pas', name: 'password' } });
       expect(registrationPage.find('RegistrationPage').state('errors')).toEqual({
-        email: '', name: '', username: '', password: 'Your password must contain at least 8 characters', country: '',
+        email: '', name: '', username: '', password: 'Password criteria has not been met', country: '',
       });
 
-      registrationPage.find('input#password').simulate('blur', { target: { value: 'passwordd', name: 'password' } });
+      registrationPage.find('input#password').simulate('blur', { target: { value: 'invalid-email', name: 'email' } });
       expect(registrationPage.find('RegistrationPage').state('errors')).toEqual({
-        email: '', name: '', username: '', password: 'Your password must contain at least 1 number.', country: '',
-      });
-
-      registrationPage.find('input#password').simulate('blur', { target: { value: '123456789', name: 'password' } });
-      expect(registrationPage.find('RegistrationPage').state('errors')).toEqual({
-        email: '', name: '', username: '', password: 'Your password must contain at least 1 letter.', country: '',
+        email: 'Enter a valid email address', name: '', username: '', password: 'Password criteria has not been met', country: '',
       });
     });
 
@@ -220,105 +219,61 @@ describe('RegistrationPage', () => {
       expect(registrationPage.find('RegistrationPage').state('errors')).toEqual(emptyFieldValidation);
     });
 
-    it('should validate field from backend on blur event', () => {
+    it('should call validation api on blur event, if frontend validations have passed', () => {
       store.dispatch = jest.fn(store.dispatch);
-
       const registrationPage = mount(reduxWrapper(<IntlRegistrationPage />));
-      IntlRegistrationPage.prototype.componentDidMount = jest.fn();
 
       // enter a valid username so that frontend validations are passed
       registrationPage.find('input#username').simulate('change', { target: { value: 'test', name: 'username' } });
       registrationPage.find('input#username').simulate('blur');
 
       const formPayload = {
-        email: '', name: '', username: 'test', password: '', country: '', honor_code: true,
+        form_field_key: 'username',
+        is_authn_mfe: true,
+        email: '',
+        name: '',
+        username: 'test',
+        password: '',
+        country: '',
+        honor_code: true,
       };
       expect(store.dispatch).toHaveBeenCalledWith(fetchRealtimeValidations(formPayload));
     });
 
-    it('should change validations and formValid state in shouldComponentUpdate', () => {
-      store = mockStore({
-        ...initialState,
-        register: {
-          ...initialState.register,
-          updateFieldErrors: false,
-        },
-      });
-      const nextProps = {
-        validations: {
-          validation_decisions: {
-            username: 'Username must be between 2 and 30 characters long.',
-          },
-        },
-        registrationError: {
-          username: [{ username: 'Username must be between 2 and 30 characters long.' }],
-        },
-      };
-
-      const root = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
-
-      // calling blur event to update the state
-      root.find('input#username').simulate('blur', { target: { value: '', name: 'username' } });
-      expect(root.find('RegistrationPage').instance().shouldComponentUpdate(nextProps)).toBe(false);
-      expect(root.find('RegistrationPage').state('formValid')).not.toEqual(true);
-    });
-
-    it('should show error message on top of screen and below the fields in case of 409', () => {
-      const errors = {
-        email: 'It looks like test@gmail.com belongs to an existing account. Try again with a different email address.',
-        username: 'It looks like test belongs to an existing account. Try again with a different username.',
-      };
+    it('should update props with validations returned by registration api', () => {
       store = mockStore({
         ...initialState,
         register: {
           ...initialState.register,
           registrationError: {
-            email: [{ user_message: errors.email }],
-            username: [{ user_message: errors.username }],
+            username: [{ userMessage: 'It looks like this username is already taken' }],
+            email: [{ userMessage: 'It looks like this email address is already registered' }],
           },
         },
       });
-
-      const nextProps = {
-        validations: null,
-        thirdPartyAuthContext: {
-          pipelineUserDetails: null,
-        },
-        registrationError: {
-          username: [{ username: errors.username }],
-        },
-      };
-
-      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
-      registrationPage.find('button.btn-brand').simulate('click');
-      registrationPage.find('RegistrationPage').instance().shouldComponentUpdate(nextProps);
-
-      expect(registrationPage.find('div[feedback-for="email"]').text()).toEqual(errors.email);
-      expect(registrationPage.find('div[feedback-for="username"]').text()).toEqual(errors.username);
-      expect(registrationPage.find('#validation-errors').first().text()).toEqual(
-        'We couldn\'t create your account.'.concat(errors.email + errors.username),
-      );
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage />)).find('RegistrationPage');
+      expect(registrationPage.prop('validationDecisions')).toEqual({
+        country: '',
+        email: 'It looks like this email address is already registered',
+        name: '',
+        password: '',
+        username: 'It looks like this username is already taken',
+      });
     });
 
-    it('test validationAlertMessages state is updated correctly', () => {
-      const validationAlertMessages = {
-        name: [{ user_message: 'Please enter your full name.' }],
-        username: [{ user_message: 'Please enter your public username.' }],
-        email: [{ user_message: 'Please enter your email.' }],
-        password: [{ user_message: 'Please enter your password.' }],
-        country: [{ user_message: 'Select your country or region of residence.' }],
+    it('should change validations in shouldComponentUpdate', () => {
+      const nextProps = {
+        thirdPartyAuthContext,
+        registrationErrorCode: 'duplicate-username',
+        validationDecisions: {
+          username: 'It looks like this username is already taken',
+        },
       };
-      store.dispatch = jest.fn(store.dispatch);
 
-      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
-
-      // submit empty form
-      registrationPage.find('button.btn-brand').simulate('click');
-      expect(registrationPage.find('RegistrationPage').state('validationAlertMessages')).toEqual(validationAlertMessages);
-
-      // simulate blur event on one of the form fields, this should not update the state
-      registrationPage.find('input#name').simulate('blur', { target: { value: 'test', name: 'name' } });
-      expect(registrationPage.find('RegistrationPage').state('validationAlertMessages')).toEqual(validationAlertMessages);
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />)).find('RegistrationPage');
+      expect(registrationPage.instance().shouldComponentUpdate(nextProps)).toBe(false);
+      expect(registrationPage.state('errors').username).toEqual('It looks like this username is already taken');
+      expect(registrationPage.state('errorCode')).toEqual('duplicate-username');
     });
 
     // ******** test alert messages ********
@@ -335,36 +290,46 @@ describe('RegistrationPage', () => {
         },
       });
 
-      const expectedMessage = 'You\'ve successfully signed into Apple. We just need a little more information before '
-                              + 'you start learning with openedX.';
+      const expectedMessage = 'You\'ve successfully signed into Apple! We just need a little more information before '
+                              + 'you start learning with edX.';
 
       const registerPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
-      expect(registerPage.find('#tpa-alert').find('span').text()).toEqual(expectedMessage);
+      expect(registerPage.find('#tpa-alert').find('p').text()).toEqual(expectedMessage);
     });
 
     it('should match internal server error message', () => {
+      const expectedMessage = 'We couldn\'t create your account.An error has occurred. Try refreshing the page, or check your internet connection.';
       props = {
-        errors: {
-          errorCode: INTERNAL_SERVER_ERROR,
-        },
+        errorCode: INTERNAL_SERVER_ERROR,
       };
 
       const registrationPage = mount(reduxWrapper(<IntlRegistrationFailure {...props} />));
       expect(registrationPage.find('div.alert-heading').length).toEqual(1);
-      const expectedMessage = 'We couldn\'t create your account.An error has occurred. Try refreshing the page, or check your internet connection.';
       expect(registrationPage.find('div.alert').first().text()).toEqual(expectedMessage);
     });
 
     it('should match registration api rate limit error message', () => {
+      const expectedMessage = 'We couldn\'t create your account.Too many failed registration attempts. Try again later.';
       props = {
-        errors: {
-          errorCode: FORBIDDEN_REQUEST,
+        errorCode: FORBIDDEN_REQUEST,
+      };
+
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationFailure {...props} />));
+      expect(registrationPage.find('div.alert-heading').length).toEqual(1);
+      expect(registrationPage.find('div.alert').first().text()).toEqual(expectedMessage);
+    });
+
+    it('should match tpa session expired error message', () => {
+      const expectedMessage = 'We couldn\'t create your account.Registration using Google has timed out.';
+      props = {
+        errorCode: TPA_SESSION_EXPIRED,
+        context: {
+          provider: 'Google',
         },
       };
 
       const registrationPage = mount(reduxWrapper(<IntlRegistrationFailure {...props} />));
       expect(registrationPage.find('div.alert-heading').length).toEqual(1);
-      const expectedMessage = 'We couldn\'t create your account.Too many failed registration attempts. Try again later.';
       expect(registrationPage.find('div.alert').first().text()).toEqual(expectedMessage);
     });
 
@@ -459,6 +424,25 @@ describe('RegistrationPage', () => {
 
       const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
       expect(registrationPage.find('input#password').length).toEqual(0);
+    });
+
+    it('should show username suggestions in case of conflict with an existing username', () => {
+      store = mockStore({
+        ...initialState,
+        register: {
+          ...initialState.register,
+          validations: {
+            usernameSuggestions: ['test_1', 'test_12', 'test_123'],
+          },
+        },
+      });
+
+      const registerPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+      registerPage.find('RegistrationPage').setState({ errors: { username: 'It looks like this username is already taken' } });
+
+      expect(registerPage.find('button.username-suggestion').length).toEqual(3);
+      registerPage.find('button.username-suggestion').at(0).simulate('click');
+      expect(registerPage.find('RegistrationPage').state('username')).toEqual('test_1');
     });
 
     // ******** test redirection ********
@@ -601,22 +585,10 @@ describe('RegistrationPage', () => {
 
     // ******** miscellaneous tests ********
 
-    it('tests shouldComponentUpdate with pipeline user data', () => {
-      const nextProps = {
-        validations: null,
-        thirdPartyAuthContext: {
-          pipelineUserDetails: {
-            name: 'test',
-            email: 'test@example.com',
-            username: 'test-username',
-          },
-        },
-      };
-
-      const root = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
-
-      const shouldUpdate = root.find('RegistrationPage').instance().shouldComponentUpdate(nextProps);
-      expect(shouldUpdate).toBe(false);
+    it('tests componentDidMount calls the reset form action', () => {
+      store.dispatch = jest.fn(store.dispatch);
+      mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+      expect(store.dispatch).toHaveBeenCalledWith(resetRegistrationForm());
     });
 
     it('should render cookie banner', () => {
@@ -629,55 +601,54 @@ describe('RegistrationPage', () => {
       expect(analytics.sendPageEvent).toHaveBeenCalledWith('login_and_registration', 'register');
     });
 
-    it('test username suggestions', () => {
-      store = mockStore({
-        ...initialState,
-        register: {
-          ...initialState.register,
-          validations: {
-            validation_decisions: {
-              username: 'It looks like test belongs to an existing account. Try again with a different username.',
-            },
-            username_suggestions: ['test_1', 'test_12', 'test_123'],
-          },
-        },
-      });
+    // ******** shouldComponentUpdate tests ********
 
-      const registerPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
-      expect(registerPage.find('button.username-suggestion').length).toEqual(3);
-      registerPage.find('button.username-suggestion').at(0).simulate('click');
-      expect(registerPage.find('RegistrationPage').state('username')).toEqual('test_1');
-    });
-
-    it('Should update state if countryCode is present in context', () => {
-      store = mockStore({
-        ...initialState,
-        commonComponents: {
-          ...initialState.commonComponents,
-          thirdPartyAuthContext: {
-            ...initialState.commonComponents.thirdPartyAuthContext,
-            countryCode: 'US',
-          },
-          thirdPartyAuthApiStatus: COMPLETE_STATE,
-        },
-      });
-
+    it('should populate form with pipeline user details', () => {
       const nextProps = {
-        validations: null,
+        registrationErrorCode: null,
         thirdPartyAuthContext: {
           pipelineUserDetails: {
-            name: 'test',
             email: 'test@example.com',
-            username: 'test-username',
           },
           countryCode: 'US',
         },
+        validationDecisions: null,
+      };
+
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />)).find('RegistrationPage');
+      registrationPage.instance().shouldComponentUpdate(nextProps);
+
+      expect(registrationPage.state('country')).toEqual('US');
+      expect(registrationPage.state('email')).toEqual('test@example.com');
+    });
+
+    it('should update state if country code is present in context', () => {
+      const nextProps = {
+        registrationErrorCode: null,
+        thirdPartyAuthContext: {
+          ...thirdPartyAuthContext,
+          countryCode: 'US',
+        },
+        validationDecisions: null,
       };
 
       const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
       const shouldUpdate = registrationPage.find('RegistrationPage').instance().shouldComponentUpdate(nextProps);
       expect(registrationPage.find('RegistrationPage').state('country')).toEqual('US');
       expect(shouldUpdate).toBe(false);
+    });
+
+    it('should update error code state with error returned by registration api', () => {
+      const nextProps = {
+        registrationErrorCode: INTERNAL_SERVER_ERROR,
+        thirdPartyAuthContext,
+        validationDecisions: null,
+      };
+
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+      registrationPage.find('RegistrationPage').instance().shouldComponentUpdate(nextProps);
+
+      expect(registrationPage.find('RegistrationPage').state('errorCode')).toEqual(INTERNAL_SERVER_ERROR);
     });
   });
 
@@ -741,6 +712,7 @@ describe('RegistrationPage', () => {
         goals: 'edX goals',
         honor_code: true,
         totalRegistrationTime: 0,
+        is_authn_mfe: true,
       };
 
       store.dispatch = jest.fn(store.dispatch);


### PR DESCRIPTION
#### Changes:
- handle empty form submission
- handle validation error messages and registration error messages

#### Notes:
- updated third party auth alert to use platform name from config
- updated validationDecision selector to consider registration errors (Only one can be present at a time, if validations rate limit only then the registration request is possible, hence it can be maintained using a single prop)
- registration failure component now displays generic message for all the error codes returned by backend except if error code matches one of the error messages in `RegistrationFailure`

|Generic registration error|Social Auth Message|
|-----|----|
<img width="539" alt="Screenshot 2021-04-29 at 5 06 22 PM" src="https://user-images.githubusercontent.com/40633976/116684022-d4e17c80-a9c9-11eb-8c2e-748787cffa53.png">|<img width="507" alt="Screenshot 2021-04-30 at 3 36 04 PM" src="https://user-images.githubusercontent.com/40633976/116684036-d7dc6d00-a9c9-11eb-9de9-92058b0ef6f2.png">


Test PR with https://github.com/edx/edx-platform/pull/27476

[VAN-288](https://openedx.atlassian.net/browse/VAN-288)