### PR TITLE
VAN-487: Add optimizely experiment

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,11 @@
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />
+      <% if (process.env.OPTIMIZELY_PROJECT_ID) { %>
+        <script
+          src="<%= process.env.MARKETING_SITE_BASE_URL %>/optimizelyjs/<%= process.env.OPTIMIZELY_PROJECT_ID %>.js"
+        ></script>
+      <% } %>
   </head>
   <body>
     <div id="root"></div>

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -75,6 +75,7 @@ class RegistrationPage extends React.Component {
       updateFieldErrors: false,
       updateAlertErrors: false,
       registrationErrorsUpdated: false,
+      optimizelyExperimentName: '',
     };
   }
 
@@ -85,6 +86,7 @@ class RegistrationPage extends React.Component {
       payload.tpa_hint = this.tpaHint;
     }
     this.props.getThirdPartyAuthContext(payload);
+    this.getExperiments();
   }
 
   shouldComponentUpdate(nextProps) {
@@ -124,6 +126,14 @@ class RegistrationPage extends React.Component {
 
     return true;
   }
+
+  getExperiments = () => {
+    const { optimizelyExperimentName } = window;
+
+    if (optimizelyExperimentName) {
+      this.setState({ optimizelyExperimentName });
+    }
+  };
 
   getCountryOptions = () => {
     const { intl } = this.props;
@@ -577,7 +587,7 @@ class RegistrationPage extends React.Component {
                     }}
                   />
                 </div>
-                {getConfig().REGISTRATION_OPTIONAL_FIELDS ? (
+                {getConfig().REGISTRATION_OPTIONAL_FIELDS && this.state.optimizelyExperimentName !== 'hide_optional_fields' ? (
                   <AuthnValidationFormGroup
                     label={intl.formatMessage(messages['support.education.research'])}
                     for="optional"

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -126,6 +126,16 @@ describe('RegistrationPageTests', () => {
     jest.clearAllMocks();
   });
 
+  it('should not show optional field check when optimizely experiment is set', () => {
+    window.optimizelyExperimentName = 'hide_optional_fields';
+
+    const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+    expect(registrationPage.find('RegistrationPage').state('optimizelyExperimentName')).toEqual('hide_optional_fields');
+    expect(registrationPage.find('#optional').length).toEqual(0);
+
+    delete window.optimizelyExperimentName;
+  });
+
   it('should toggle optional fields state on checkbox click', () => {
     const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
 


### PR DESCRIPTION
#### Scope
Conduct an A/B test via Optimizely where 50% of users will see optional fields and the other 50% of users will not see these fields on the registration form.

Run this test for a week; we are looking for an answer to the question:
What impact does removing optional fields from the registration form has on the registration rate?
- Measure OGSP registration rate.
- Measure registration page conversion rate.

#### Notes:
The 50% of traffic that will not be shown optional fields will set the `optimizelyExperimentName` to `hide_optional_fields` in optimzely

Ticket: https://openedx.atlassian.net/browse/VAN-487