### PR TITLE
update submit button state

### DIFF
--- a/src/common-components/messages.jsx
+++ b/src/common-components/messages.jsx
@@ -73,7 +73,7 @@ const messages = defineMessages({
   },
   'start.learning': {
     id: 'start.learning',
-    defaultMessage: 'Start Learning',
+    defaultMessage: 'Start learning',
     description: 'Header text for logistration MFE pages',
   },
   'with.site.name': {

--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -100,6 +100,7 @@ const ForgotPasswordPage = (props) => {
                   state={submitState}
                   labels={{
                     default: intl.formatMessage(messages['forgot.password.page.submit.button']),
+                    pending: '',
                   }}
                   icons={{ pending: <FontAwesomeIcon icon={faSpinner} spin /> }}
                   onClick={handleSubmit}


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

1. The submit state of the button on Forgot Password Form is updated.
2. A typo is addressed on Landing page
## Supporting information

https://openedx.atlassian.net/browse/VAN-524
https://openedx.atlassian.net/browse/VAN-521

## Testing instructions

After shipping this change to staging and production environment, a user can experience a consistent behavior while submission on Register and Forgot Password Forms.