### PR TITLE
fix: Clear error state on focus

### DIFF
--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -91,6 +91,7 @@ const ForgotPasswordPage = (props) => {
                   value={values.email}
                   handleBlur={() => getValidationMessage(values.email)}
                   handleChange={e => setFieldValue('email', e.target.value)}
+                  handleFocus={() => setValidationError('')}
                   helpText={[intl.formatMessage(messages['forgot.password.email.help.text'], { platformName })]}
                 />
                 <StatefulButton

--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -85,7 +85,7 @@ const ResetPasswordPage = (props) => {
   };
 
   const handleOnFocus = (e) => {
-    setFormErrors({ [e.target.name]: '' });
+    setFormErrors({ ...formErrors, [e.target.name]: '' });
   };
 
   const handleSubmit = (e) => {


### PR DESCRIPTION
- On forgot password page clear email field error state on focus event.
- On reset password page clear error state of field only which has focused in.

VAN-505