### PR TITLE
fix issues in typeahead

### DIFF
--- a/src/register/CountryDropdown.jsx
+++ b/src/register/CountryDropdown.jsx
@@ -21,7 +21,7 @@ class CountryDropdown extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    if (this.props.value !== nextProps.value) {
+    if (this.props.value !== nextProps.value && nextProps.value !== null) {
       const opt = this.props.options.find((o) => o[this.props.valueKey] === nextProps.value);
       if (opt && opt[this.props.displayValueKey] !== this.state.displayValue) {
         this.setState({ displayValue: opt[this.props.displayValueKey], showFieldError: false });
@@ -87,12 +87,15 @@ class CountryDropdown extends React.Component {
     }
   }
 
-  handleClick = () => {
+  handleClick = (e) => {
     if (!this.props.value) {
-      const dropDownItems = this.getItems();
+      const dropDownItems = this.getItems(e.target.value);
       this.setState({
         dropDownItems, icon: ExpandLess, errorMessage: '', showFieldError: false,
       });
+    }
+    if (this.state.dropDownItems?.length > 0) {
+      this.setState({ dropDownItems: '', icon: ExpandMore });
     }
   }
 


### PR DESCRIPTION
Following issues identified in Product review are fixed:

1. I land on page and there is a autopopulated country ‘Pakistan’; when I focus in and press ‘Delete’ from keyboard; it does not delete the last character of the selected country; when I press ‘Delete’ the second time; then it successfully deletes the last character.
2. When i enter characters in the typeahead; it filters dropdown options;  i focus out of field and then i focus in again on the field and it dhows all countries instead of filtered countries for what i enetered.
3. When i click on arrow icon on the right; it open dropdown and shows all countried; it should show only filtered countries; when i click again on the arrow icon; it does not close the dropdown.