### PR TITLE
fix: clear username suggestion of field focus

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -244,6 +244,8 @@ class RegistrationPage extends React.Component {
     const state = { errors };
     if (e.target.name === 'email') {
       state.skipEmailValidation = false;
+    } else if (e.target.name === 'username') {
+      this.props.clearUsernameSuggestions();
     }
     this.setState({ ...state });
   }

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -10,7 +10,12 @@ import { getConfig, mergeConfig } from '@edx/frontend-platform';
 import * as analytics from '@edx/frontend-platform/analytics';
 import { IntlProvider, injectIntl, configure } from '@edx/frontend-platform/i18n';
 
-import { fetchRealtimeValidations, registerNewUser, resetRegistrationForm } from '../data/actions';
+import {
+  clearUsernameSuggestions,
+  fetchRealtimeValidations,
+  registerNewUser,
+  resetRegistrationForm,
+} from '../data/actions';
 import { FORBIDDEN_REQUEST, INTERNAL_SERVER_ERROR, TPA_SESSION_EXPIRED } from '../data/constants';
 import RegistrationFailureMessage from '../RegistrationFailure';
 import RegistrationPage from '../RegistrationPage';
@@ -293,7 +298,7 @@ describe('RegistrationPage', () => {
       expect(registrationPage.state('errorCode')).toEqual('duplicate-username');
     });
 
-    // ******** test clear error messages on focus in ********
+    // ******** test field focus in functionality ********
 
     it('should clear field related error messages on input field Focus', () => {
       const errors = {
@@ -317,6 +322,15 @@ describe('RegistrationPage', () => {
       expect(registrationPage.find('div[feedback-for="country"]').text()).toEqual(emptyFieldValidation.country);
       registrationPage.find('input#country').simulate('blur', { target: { value: 'US', name: 'country' } });
       expect(registrationPage.find('RegistrationPage').state('errors')).toEqual(errors);
+    });
+
+    it('should clear username suggestions when username field is focused in', () => {
+      store.dispatch = jest.fn(store.dispatch);
+
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+      registrationPage.find('input#username').simulate('focus');
+
+      expect(store.dispatch).toHaveBeenCalledWith(clearUsernameSuggestions());
     });
 
     // ******** test alert messages ********


### PR DESCRIPTION
#### Context:
If a user enters “edx” (already registered username) they will receive the below suggestion. This is the correct behaviour.

<img width="500" alt="Screenshot 2021-06-15 at 5 47 54 PM" src="https://user-images.githubusercontent.com/40633976/122055250-dcd27000-ce01-11eb-912a-1b073a1417ee.png">

If the user then clears their entry and types “b”, they receive the suggestions from their previous entry:
<img width="500" alt="Screenshot 2021-06-15 at 5 48 04 PM" src="https://user-images.githubusercontent.com/40633976/122055257-df34ca00-ce01-11eb-9704-d24ef718c55e.png">

We are already clearing username field error on field focus we just need to clear username suggestions as well.

#### Ticket:
https://openedx.atlassian.net/browse/VAN-603
