### PR TITLE
fix typos in login failure messages

### DIFF
--- a/src/redesign/login/LoginFailure.jsx
+++ b/src/redesign/login/LoginFailure.jsx
@@ -24,31 +24,23 @@ const LoginFailureMessage = (props) => {
   let errorList;
   let link;
   let resetLink = (
-    <>
-      <a href="/reset">
-        {intl.formatMessage(messages['login.incorrect.credentials.error.reset.link.text'])}
-      </a>
-    </>
+    <a href="/reset">
+      {intl.formatMessage(messages['login.incorrect.credentials.error.reset.link.text'])}
+    </a>
   );
 
   switch (errorCode) {
     case NON_COMPLIANT_PASSWORD_EXCEPTION: {
       errorList = (
-        <FormattedMessage
-          id="non.compliant.password.error"
-          defaultMessage="{passwordComplaintRequirements} {lineBreak}Your current password does not meet the new security
-          requirements. We just sent a password-reset message to the email address associated with this account.
-          Thank you for helping us keep your data safe."
-          values={{
-            passwordComplaintRequirements: <strong>{intl.formatMessage(messages['non.compliant.password.title'])}</strong>,
-            lineBreak: <br />,
-          }}
-        />
+        <>
+          <strong>{intl.formatMessage(messages['non.compliant.password.title'])}</strong>
+          <p>{intl.formatMessage(messages['non.compliant.password.message'])}</p>
+        </>
       );
       break;
     }
     case FORBIDDEN_REQUEST:
-      errorList = intl.formatMessage(messages['login.rate.limit.reached.message']);
+      errorList = <p>{intl.formatMessage(messages['login.rate.limit.reached.message'])}</p>;
       break;
     case INACTIVE_USER: {
       const supportLink = (
@@ -57,25 +49,27 @@ const LoginFailureMessage = (props) => {
         </a>
       );
       errorList = (
-        <FormattedMessage
-          id="login.inactive.user.error"
-          defaultMessage="In order to sign in, you need to activate your account.{lineBreak}
-          {lineBreak}We just sent an activation link to {email}. If you do not receive an email,
-          check your spam folders or {supportLink}."
-          values={{
-            lineBreak: <br />,
-            email: <strong className="data-hj-suppress">{props.loginError.email}</strong>,
-            supportLink,
-          }}
-        />
+        <p>
+          <FormattedMessage
+            id="login.inactive.user.error"
+            defaultMessage="In order to sign in, you need to activate your account.{lineBreak}
+            {lineBreak}We just sent an activation link to {email}. If you do not receive an email,
+            check your spam folders or {supportLink}."
+            values={{
+              lineBreak: <br />,
+              email: <strong className="data-hj-suppress">{props.loginError.email}</strong>,
+              supportLink,
+            }}
+          />
+        </p>
       );
       break;
     }
     case INTERNAL_SERVER_ERROR:
-      errorList = intl.formatMessage(messages['internal.server.error.message']);
+      errorList = <p>{intl.formatMessage(messages['internal.server.error.message'])}</p>;
       break;
     case INVALID_FORM:
-      errorList = intl.formatMessage(messages['login.form.invalid.error.message']);
+      errorList = <p>{intl.formatMessage(messages['login.form.invalid.error.message'])}</p>;
       break;
     case FAILED_LOGIN_ATTEMPT: {
       resetLink = (
@@ -84,33 +78,41 @@ const LoginFailureMessage = (props) => {
         </a>
       );
       errorList = (
-        <FormattedMessage
-          id="login.incorrect.credentials.error.attempts.text"
-          description="Error message for incorrect email or password including attempts"
-          defaultMessage="The username, email or password you entered is incorrect. You have {remainingAttempts} more sign in
-            attempts before your account is temporarily locked.{lineBreak}
-            {lineBreak}If you've forgotten your password, {resetLink}"
-          values={{
-            lineBreak: <br />,
-            remainingAttempts: context.remainingAttempts,
-            resetLink,
-          }}
-        />
+        <>
+          <p>
+            <FormattedMessage
+              id="login.incorrect.credentials.error.attempts.text.1"
+              description="Error message for incorrect email or password"
+              defaultMessage="The username, email or password you entered is incorrect. You have {remainingAttempts} more sign in
+                attempts before your account is temporarily locked."
+              values={{ remainingAttempts: context.remainingAttempts }}
+            />
+          </p>
+          <p>
+            <FormattedMessage
+              id="login.incorrect.credentials.error.attempts.text.2"
+              description="Part of error message for incorrect email or password"
+              defaultMessage="If you've forgotten your password, {resetLink}"
+              values={{ resetLink }}
+            />
+          </p>
+        </>
       );
       break;
     }
     case ACCOUNT_LOCKED_OUT: {
       errorList = (
-        <FormattedMessage
-          id="login.locked.out.error.message"
-          description="Account locked out user message"
-          defaultMessage="To protect your account, its been temporarily locked. Try again in 30 minutes. {lineBreak}
-          {lineBreak} To be on the safe side, you can {resetLink} before try again."
-          values={{
-            lineBreak: <br />,
-            resetLink,
-          }}
-        />
+        <>
+          <p>{intl.formatMessage(messages['account.locked.out.message.1'])}</p>
+          <p>
+            <FormattedMessage
+              id="account.locked.out.message.2"
+              description="Part of message for when user account has been locked out after multiple failed login attempts"
+              defaultMessage="To be on the safe side, you can {resetLink} before trying again."
+              values={{ resetLink }}
+            />
+          </p>
+        </>
       );
       break;
     }
@@ -119,11 +121,13 @@ const LoginFailureMessage = (props) => {
         errorList = intl.formatMessage(messages['login.incorrect.credentials.error']);
       } else if (context.failureCount === 2) {
         errorList = (
-          <FormattedMessage
-            id="login.incorrect.credentials.error.with.reset.link"
-            defaultMessage="The username, email or password you entered is incorrect. Please try again or {resetLink}."
-            values={{ resetLink }}
-          />
+          <p>
+            <FormattedMessage
+              id="login.incorrect.credentials.error.with.reset.link"
+              defaultMessage="The username, email, or password you entered is incorrect. Please try again or {resetLink}."
+              values={{ resetLink }}
+            />
+          </p>
         );
       }
       break;
@@ -154,7 +158,7 @@ const LoginFailureMessage = (props) => {
   return (
     <Alert id="login-failure-alert" className="mb-5" variant="danger" icon={Error}>
       <Alert.Heading>{intl.formatMessage(messages['login.failure.header.title'])}</Alert.Heading>
-      <p>{ errorList }</p>
+      { errorList }
     </Alert>
   );
 };

--- a/src/redesign/login/messages.jsx
+++ b/src/redesign/login/messages.jsx
@@ -87,6 +87,18 @@ const messages = defineMessages({
     defaultMessage: 'We recently changed our password requirements',
     description: 'A title that appears in bold before error message for non-compliant password',
   },
+  'non.compliant.password.message': {
+    id: 'non.compliant.password.message',
+    defaultMessage: 'Your current password does not meet the new security requirements. '
+                    + 'We just sent a password-reset message to the email address associated with this account. '
+                    + 'Thank you for helping us keep your data safe.',
+    description: 'Error message for non-compliant password',
+  },
+  'account.locked.out.message.1': {
+    id: 'account.locked.out.message.1',
+    defaultMessage: 'To protect your account, it\'s been temporarily locked. Try again in 30 minutes.',
+    description: 'Part of message for when user account has been locked out after multiple failed login attempts',
+  },
   'first.time.here': {
     id: 'first.time.here',
     defaultMessage: 'First time here?',
@@ -180,13 +192,8 @@ const messages = defineMessages({
   },
   'login.incorrect.credentials.error': {
     id: 'login.incorrect.credentials.error',
-    defaultMessage: 'The username, email or password you entered is incorrect. Please try again.',
+    defaultMessage: 'The username, email, or password you entered is incorrect. Please try again.',
     description: 'Error message for incorrect email or password',
-  },
-  'login.incorrect.credentials.error.with.reset.link': {
-    id: 'login.incorrect.credentials.error.with.reset.link',
-    defaultMessage: 'The username, email or password you entered is incorrect. Please try again or {resetLink}.',
-    description: 'Error message for incorrect email or password with reset link',
   },
   'login.failed.attempt.error': {
     id: 'login.failed.attempt.error',

--- a/src/redesign/login/tests/LoginFailure.test.jsx
+++ b/src/redesign/login/tests/LoginFailure.test.jsx
@@ -32,7 +32,7 @@ describe('LoginFailureMessage', () => {
       </IntlProvider>,
     );
 
-    const expectedMessage = 'We couldn\'t sign you in.We recently changed our password requirements '
+    const expectedMessage = 'We couldn\'t sign you in.We recently changed our password requirements'
                             + 'Your current password does not meet the new security requirements. We just sent a '
                             + 'password-reset message to the email address associated with this account. '
                             + 'Thank you for helping us keep your data safe.';
@@ -85,7 +85,7 @@ describe('LoginFailureMessage', () => {
       </IntlProvider>,
     );
     const expectedMessage = 'We couldn\'t sign you in.The username, email or password you entered is incorrect. '
-                            + 'You have 3 more sign in attempts before your account is temporarily locked. If you\'ve forgotten your password, click here to reset it.';
+                            + 'You have 3 more sign in attempts before your account is temporarily locked.If you\'ve forgotten your password, click here to reset it.';
 
     expect(loginFailureMessage.find('#login-failure-alert').first().text()).toEqual(expectedMessage);
   });
@@ -107,7 +107,7 @@ describe('LoginFailureMessage', () => {
         <IntlLoginFailureMessage {...props} />
       </IntlProvider>,
     );
-    const expectedMessage = 'We couldn\'t sign you in.The username, email or password you entered is incorrect. Please try again.';
+    const expectedMessage = 'We couldn\'t sign you in.The username, email, or password you entered is incorrect. Please try again.';
 
     expect(loginFailureMessage.find('#login-failure-alert').first().text()).toEqual(expectedMessage);
   });
@@ -129,7 +129,7 @@ describe('LoginFailureMessage', () => {
         <IntlLoginFailureMessage {...props} />
       </IntlProvider>,
     );
-    const expectedMessage = 'We couldn\'t sign you in.The username, email or password you entered is incorrect. Please try again or reset your password.';
+    const expectedMessage = 'We couldn\'t sign you in.The username, email, or password you entered is incorrect. Please try again or reset your password.';
 
     expect(loginFailureMessage.find('#login-failure-alert').first().text()).toEqual(expectedMessage);
   });


### PR DESCRIPTION
- Fixed a few typos in the login failure messages
- Updated messages to be inside paragraphs instead of being separated by line breaks. 

<img width="320" alt="Screenshot 2021-06-16 at 6 45 50 PM" src="https://user-images.githubusercontent.com/40633976/122230467-2048df00-ced3-11eb-857b-058ca37d4dc1.png">
<img width="320" alt="Screenshot 2021-06-16 at 6 46 01 PM" src="https://user-images.githubusercontent.com/40633976/122230482-2343cf80-ced3-11eb-8d14-522aa7a85875.png">

Ticket: https://openedx.atlassian.net/browse/VAN-612
