### PR TITLE
fix: Password field icon size

### DIFF
--- a/src/redesign/_style.scss
+++ b/src/redesign/_style.scss
@@ -648,13 +648,6 @@ select.form-control {
       text-decoration: underline;
     }
 }
-.password-visibility{
-  .btn-icon__icon-container .btn-icon__icon {
-    height: 1.5rem !important;
-    width: 1.5rem !important;
-    color: $gray-500;
-  }
-}
 
 .arrow-back-icon {
   margin-top:2px;

--- a/src/redesign/common-components/PasswordField.jsx
+++ b/src/redesign/common-components/PasswordField.jsx
@@ -30,11 +30,11 @@ const PasswordField = (props) => {
   };
 
   const HideButton = (
-    <IconButton onFocus={handleFocus} onBlur={handleBlur} name="passwordValidation" className="password-visibility" src={VisibilityOff} iconAs={Icon} onClick={setHiddenTrue} size="sm" variant="secondary" alt={formatMessage(messages['hide.password'])} />
+    <IconButton onFocus={handleFocus} onBlur={handleBlur} name="passwordValidation" src={VisibilityOff} iconAs={Icon} onClick={setHiddenTrue} size="sm" variant="secondary" alt={formatMessage(messages['hide.password'])} />
   );
 
   const ShowButton = (
-    <IconButton onFocus={handleFocus} onBlur={handleBlur} name="passwordValidation" className="password-visibility" src={Visibility} iconAs={Icon} onClick={setHiddenFalse} size="sm" variant="secondary" alt={formatMessage(messages['show.password'])} />
+    <IconButton onFocus={handleFocus} onBlur={handleBlur} name="passwordValidation" src={Visibility} iconAs={Icon} onClick={setHiddenFalse} size="sm" variant="secondary" alt={formatMessage(messages['show.password'])} />
   );
   const placement = window.innerWidth < 768 ? 'top' : 'left';
   const tooltip = (


### PR DESCRIPTION
- set password field icon size according to figma design.

**Before:**
<img width="494" alt="before" src="https://user-images.githubusercontent.com/78487564/122548104-5ceb1680-d04a-11eb-84ec-15eac61357a3.png">
**After:**
<img width="503" alt="after" src="https://user-images.githubusercontent.com/78487564/122548147-68d6d880-d04a-11eb-9e27-6d4122d2df62.png">

VAN-523