### PR TITLE
VAN-598: update email warnings and errors

### DIFF
--- a/src/redesign/register/data/constants.js
+++ b/src/redesign/register/data/constants.js
@@ -34,11 +34,11 @@ export const GENDER_OPTIONS = ['', 'f', 'm', 'o'];
 // Other constants
 export const FORM_FIELDS = ['name', 'email', 'password', 'username', 'country'];
 
-export const COMMON_VALID_EMAIL_DOMAINS = [
-  'edx.org', 'hotmail.com', 'yahoo.com', 'outlook.com', 'live.com', 'gmail.com',
+export const COMMON_EMAIL_PROVIDERS = [
+  'hotmail.com', 'yahoo.com', 'outlook.com', 'live.com', 'gmail.com', 'aol.com',
 ];
 
-export const DEFAULT_SERVICE_PROVIDER_DOMAINS = ['yahoo', 'hotmail', 'live', 'outlook', 'gmail', 'edx'];
+export const DEFAULT_SERVICE_PROVIDER_DOMAINS = ['yahoo', 'aol', 'hotmail', 'live', 'outlook', 'gmail'];
 
 export const DEFAULT_TOP_LEVEL_DOMAINS = [
   'aaa', 'aarp', 'abarth', 'abb', 'abbott', 'abbvie', 'abc', 'able', 'abogado', 'abudhabi', 'ac', 'academy',

--- a/src/redesign/register/utils.js
+++ b/src/redesign/register/utils.js
@@ -1,6 +1,7 @@
 import { distance } from 'fastest-levenshtein';
+import { COMMON_EMAIL_PROVIDERS } from './data/constants';
 
-export default function getLevenshteinSuggestion(word, knownWords, similarityThreshold = 4) {
+export function getLevenshteinSuggestion(word, knownWords, similarityThreshold = 4) {
   if (!word) {
     return null;
   }
@@ -17,4 +18,25 @@ export default function getLevenshteinSuggestion(word, knownWords, similarityThr
   }
 
   return minEditDistance <= similarityThreshold && word !== mostSimilar ? mostSimilar : null;
+}
+
+export function getSuggestionForInvalidEmail(domain, username) {
+  if (!domain) {
+    return null;
+  }
+
+  const defaultDomains = ['yahoo', 'aol', 'hotmail', 'live', 'outlook', 'gmail'];
+  const suggestion = getLevenshteinSuggestion(domain, COMMON_EMAIL_PROVIDERS);
+
+  if (suggestion) {
+    return `${username}@${suggestion}`;
+  }
+
+  for (let i = 0; i < defaultDomains.length; i++) {
+    if (domain.includes(defaultDomains[i])) {
+      return `${username}@${defaultDomains[i]}.com`;
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
context:
Following are the issues reported by Jon after verification:

Input | Expected result | Actual result
-- | -- | --
jon@protonmail.com | No warning or suggestion | Warning + jon@hotmail.com
jon@aol.com | No warning or suggestion | Warning + jon@yahoo.com
jon@harvard.fas.edu|No warning or suggestion|Error + jon@harvard.as

The fix removes these issue ^
- Added a check to ignore email addresses with multiple subdomains
- Updated suggestion for valid email addresses with no service and tld suggestions to use edit distance of 3 instead of 4(default)

Ticket: https://openedx.atlassian.net/browse/VAN-598