### PR TITLE
fix: fix overlapping over logo

### DIFF
--- a/src/redesign/_style.scss
+++ b/src/redesign/_style.scss
@@ -709,3 +709,9 @@ select.form-control {
   margin-top: 0.188rem !important;
   line-height: 1.25rem;
 }
+
+@media (max-height: 500px) {
+  .large-screen-svg-line, .large-heading {
+    margin-top: 5rem;
+  }
+}


### PR DESCRIPTION
- fix start learning with edx text overlapping over logo.

**Before**
<img width="509" alt="Screen Shot 2021-07-02 at 3 30 37 PM" src="https://user-images.githubusercontent.com/78487564/124261734-917ec800-db4a-11eb-9faf-851c895c1ed9.png">


**After**
<img width="544" alt="after" src="https://user-images.githubusercontent.com/78487564/124261472-45cc1e80-db4a-11eb-8062-9c70cc9ffa5d.png">


VAN-606