### PR TITLE
fix: remove opacity on stateful button

### DIFF
--- a/src/redesign/_style.scss
+++ b/src/redesign/_style.scss
@@ -709,3 +709,7 @@ select.form-control {
   margin-top: 0.188rem !important;
   line-height: 1.25rem;
 }
+
+.no-opacity {
+  opacity: 1 !important;
+}

--- a/src/redesign/login/LoginPage.jsx
+++ b/src/redesign/login/LoginPage.jsx
@@ -245,7 +245,7 @@ class LoginPage extends React.Component {
             <StatefulButton
               type="submit"
               variant="brand"
-              className="login-button-width"
+              className={submitState === 'pending' ? 'login-button-width no-opacity' : 'login-button-width'}
               state={submitState}
               labels={{
                 default: intl.formatMessage(messages['sign.in.button']),


### PR DESCRIPTION
Remove the opacity on pending state of the stateful button so that a crisp original color would be displayed in pending state.

VAN-605