### PR TITLE
fix: login/register SAML page style

### DIFF
--- a/src/redesign/_style.scss
+++ b/src/redesign/_style.scss
@@ -232,6 +232,7 @@ $accent-a-light: #c9f2f5;
   @extend .text-gray;
 
   display: inline-block;
+  margin-bottom: 0.25rem;
   height: 18px;
   width: 18px;
 
@@ -723,4 +724,15 @@ select.form-control {
     margin-right: calc(100% - 100vw);
     margin-left: 0;
   }
+}
+
+.table-striped tbody tr:nth-of-type(odd) {
+  background-color: $light-200;
+}
+
+.secondary-provider-link {
+  font-weight: normal;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: $primary-700
 }

--- a/src/redesign/common-components/InstitutionLogistration.jsx
+++ b/src/redesign/common-components/InstitutionLogistration.jsx
@@ -11,7 +11,7 @@ export const RenderInstitutionButton = props => {
 
   return (
     <Button
-      className="btn btn-link btn-sm text-body p-0 mb-4"
+      className="btn-sm text-body p-0 mb-4 border-0"
       variant="link"
       data-event-name="institution_login"
       onClick={onSubmitHandler}
@@ -32,7 +32,7 @@ const InstitutionLogistration = props => {
 
   return (
     <>
-      <div className="d-flex justify-content-left mb-4 mt-4">
+      <div className="d-flex justify-content-left mb-4 mt-2">
         <div className="flex-column">
           <h4 className="mb-2 font-weight-bold institute-heading">
             {headingTitle}
@@ -49,7 +49,7 @@ const InstitutionLogistration = props => {
               <tr key={provider} className="pgn__data-table-row">
                 <td>
                   <Hyperlink
-                    className="btn nav-item p-0 mb-1"
+                    className="btn nav-item p-0 mb-1 secondary-provider-link"
                     destination={lmsBaseUrl + provider.loginUrl}
                   >
                     {provider.name}

--- a/src/redesign/common-components/Logistration.jsx
+++ b/src/redesign/common-components/Logistration.jsx
@@ -25,7 +25,11 @@ const Logistration = (props) => {
 
   const handleInstitutionLogin = (e) => {
     sendTrackEvent('edx.bi.institution_login_form.toggled', { category: 'user-engagement' });
-    sendPageEvent('login_and_registration', e.target.dataset.eventName);
+    if (typeof e === 'string') {
+      sendPageEvent('login_and_registration', e === '/login' ? 'login' : 'register');
+    } else {
+      sendPageEvent('login_and_registration', e.target.dataset.eventName);
+    }
 
     setInstitutionLogin(!institutionLogin);
   };
@@ -57,7 +61,7 @@ const Logistration = (props) => {
         : (
           <>
             {!tpa && (
-              <Tabs defaultActiveKey={selectedPage} id="controlled-tab-example" onSelect={handleOnSelect}>
+              <Tabs defaultActiveKey={selectedPage} id="controlled-tab" onSelect={handleOnSelect}>
                 <Tab title={intl.formatMessage(messages['logistration.register'])} eventKey={REGISTER_PAGE} />
                 <Tab title={intl.formatMessage(messages['logistration.sign.in'])} eventKey={LOGIN_PAGE} />
               </Tabs>


### PR DESCRIPTION
- update SAML page style according to figma style.

**After Fix:**
SAML link
<img width="585" alt="Screen Shot 2021-07-15 at 6 24 37 PM" src="https://user-images.githubusercontent.com/78487564/125800569-76a894b7-48ce-4650-ac9c-e135ac6edc8d.png">

SAML Page
<img width="1313" alt="Screen Shot 2021-07-15 at 6 24 53 PM" src="https://user-images.githubusercontent.com/78487564/125800646-f29e2786-263e-460f-9adb-5388c591ce85.png">

**Figma Design:**
https://www.figma.com/file/0uBm1o7nH2ExePrRXGvB7Z/Logistration?node-id=1018%3A12582

**How to test locally:**
- set `DISABLE_ENTERPRISE_LOGIN=true` in `.env.development`.
- restart node server.

VAN-64