### PR TITLE
fix: header text for Spanish

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -505,7 +505,7 @@ select.form-control {
 .large-heading {
   margin-left: 7px;
   color: $white;
-  max-width: 24rem;
+  max-width: 24.5rem;
   line-height: 78px;
   font-size: 78px;
 }


### PR DESCRIPTION
## Before
<img width="686" alt="Screenshot 2021-07-30 at 3 12 07 PM" src="https://user-images.githubusercontent.com/2851134/127638695-f0ddb37e-6d0a-4c3b-9888-eddd7001ae5d.png">

## After
<img width="705" alt="Screenshot 2021-07-30 at 3 11 54 PM" src="https://user-images.githubusercontent.com/2851134/127638701-31a23b72-5dcb-4aa5-9875-810c94fcdf1f.png">
