### PR TITLE
fix: reset password banner image changed

### DIFF
--- a/src/base-component/BaseComponent.jsx
+++ b/src/base-component/BaseComponent.jsx
@@ -17,8 +17,8 @@ import AuthExtraLargeLayout from './AuthExtraLargeLayout';
 import AuthMediumLayout from './AuthMediumLayout';
 import AuthSmallLayout from './AuthSmallLayout';
 
-const BaseComponent = ({ children }) => {
-  const authenticatedUser = getAuthenticatedUser();
+const BaseComponent = ({ children, showWelcomeBanner }) => {
+  const authenticatedUser = showWelcomeBanner ? getAuthenticatedUser() : null;
 
   return (
     <>
@@ -62,8 +62,13 @@ const BaseComponent = ({ children }) => {
   );
 };
 
+BaseComponent.defaultProps = {
+  showWelcomeBanner: false,
+};
+
 BaseComponent.propTypes = {
   children: PropTypes.node.isRequired,
+  showWelcomeBanner: PropTypes.bool,
 };
 
 export default BaseComponent;

--- a/src/welcome/WelcomePage.jsx
+++ b/src/welcome/WelcomePage.jsx
@@ -122,7 +122,7 @@ const WelcomePage = (props) => {
 
   return (
     <>
-      <BaseComponent>
+      <BaseComponent showWelcomeBanner>
         <Helmet>
           <title>{intl.formatMessage(messages['progressive.profiling.page.title'],
             { siteName: getConfig().SITE_NAME })}


### PR DESCRIPTION
In addition to the check for authenticated user, added a welcome banner check to restrict the welcome banner for only progressive profiling page.

|Reset password page now has the correct banner|Welcome page banner is only for PP|
|-------|------|
<img width="1916" alt="Screenshot 2021-08-12 at 4 37 43 PM" src="https://user-images.githubusercontent.com/40633976/129191622-20078f3a-4c1e-4899-8599-924c8a9b7b03.png">|<img width="1916" alt="Screenshot 2021-08-12 at 4 42 12 PM" src="https://user-images.githubusercontent.com/40633976/129191638-70956558-fe1f-4a07-831f-e76150dcafb6.png">


[VAN-688](https://openedx.atlassian.net/browse/VAN-688)