### PR TITLE
fix: SSO *Apple* translated in authn pages.

### DIFF
--- a/src/common-components/SocialAuthProviders.jsx
+++ b/src/common-components/SocialAuthProviders.jsx
@@ -42,7 +42,7 @@ function SocialAuthProviders(props) {
             </div>
           </>
         )}
-      <span id="provider-name" className="mr-auto pl-2" aria-hidden="true">{provider.name}</span>
+      <span id="provider-name" className="notranslate mr-auto pl-2" aria-hidden="true">{provider.name}</span>
       <span className="sr-only">
         {referrer === LOGIN_PAGE
           ? intl.formatMessage(messages['sso.sign.in.with'], { providerName: provider.name })

--- a/src/common-components/tests/__snapshots__/SocialAuthProviders.test.jsx.snap
+++ b/src/common-components/tests/__snapshots__/SocialAuthProviders.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`SocialAuthProviders should match social auth provider with default icon
   </div>
   <span
     aria-hidden="true"
-    className="mr-auto pl-2"
+    className="notranslate mr-auto pl-2"
     id="provider-name"
   >
     Apple
@@ -77,7 +77,7 @@ exports[`SocialAuthProviders should match social auth provider with iconClass sn
   </div>
   <span
     aria-hidden="true"
-    className="mr-auto pl-2"
+    className="notranslate mr-auto pl-2"
     id="provider-name"
   >
     Apple
@@ -110,7 +110,7 @@ Array [
     </div>
     <span
       aria-hidden="true"
-      className="mr-auto pl-2"
+      className="notranslate mr-auto pl-2"
       id="provider-name"
     >
       Apple
@@ -139,7 +139,7 @@ Array [
     </div>
     <span
       aria-hidden="true"
-      className="mr-auto pl-2"
+      className="notranslate mr-auto pl-2"
       id="provider-name"
     >
       Facebook


### PR DESCRIPTION
### Description:
A brand name *Apple* should not be translated when page language changes. I have fix it in this PR.
[https://openedx.atlassian.net/browse/VAN-717](https://openedx.atlassian.net/browse/VAN-717)

Here is the attached Video:

https://user-images.githubusercontent.com/7627421/133074896-4e43e51e-a07f-44e6-aab7-37bc2ebf0583.mov

