### PR TITLE
refactor: update account verification messages

### DIFF
--- a/src/login/AccountActivationMessage.jsx
+++ b/src/login/AccountActivationMessage.jsx
@@ -13,6 +13,8 @@ const AccountActivationMessage = (props) => {
   const { intl, messageType } = props;
   const variant = messageType === ACCOUNT_ACTIVATION_MESSAGE.ERROR ? 'danger' : messageType;
 
+  const activationOrVerification = getConfig().MARKETING_EMAILS_OPT_IN ? 'confirmation' : 'activation';
+
   let activationMessage;
   let heading;
 
@@ -23,12 +25,12 @@ const AccountActivationMessage = (props) => {
 
   switch (messageType) {
     case ACCOUNT_ACTIVATION_MESSAGE.SUCCESS: {
-      heading = intl.formatMessage(messages['account.activation.success.message.title']);
-      activationMessage = intl.formatMessage(messages['account.activation.success.message']);
+      heading = intl.formatMessage(messages[`account.${activationOrVerification}.success.message.title`]);
+      activationMessage = <span>{intl.formatMessage(messages[`account.${activationOrVerification}.success.message`])}</span>;
       break;
     }
     case ACCOUNT_ACTIVATION_MESSAGE.INFO: {
-      activationMessage = intl.formatMessage(messages['account.already.activated.message']);
+      activationMessage = intl.formatMessage(messages[`account.${activationOrVerification}.info.message`]);
       break;
     }
     case ACCOUNT_ACTIVATION_MESSAGE.ERROR: {
@@ -38,7 +40,7 @@ const AccountActivationMessage = (props) => {
         </Alert.Link>
       );
 
-      heading = intl.formatMessage(messages['account.activation.error.message.title']);
+      heading = intl.formatMessage(messages[`account.${activationOrVerification}.error.message.title`]);
       activationMessage = (
         <FormattedMessage
           id="account.activation.error.message"

--- a/src/login/messages.jsx
+++ b/src/login/messages.jsx
@@ -155,8 +155,8 @@ const messages = defineMessages({
     defaultMessage: 'You will now receive email updates and alerts from us related to the courses you are enrolled in. Sign in to continue.',
     description: 'Message show to learners when their account has been activated successfully',
   },
-  'account.already.activated.message': {
-    id: 'account.already.activated.message',
+  'account.activation.info.message': {
+    id: 'account.activation.info.message',
     defaultMessage: 'This account has already been activated.',
     description: 'Message shown when learner account has already been activated',
   },
@@ -169,6 +169,27 @@ const messages = defineMessages({
     id: 'account.activation.support.link',
     defaultMessage: 'contact support',
     description: 'Link text used in account activation error message to go to learner help center',
+  },
+  // Email Confirmation Strings
+  'account.confirmation.success.message.title': {
+    id: 'account.confirmation.success.message.title',
+    defaultMessage: 'Success! You have confirmed your email.',
+    description: 'Account verification success message title',
+  },
+  'account.confirmation.success.message': {
+    id: 'account.confirmation.success.message',
+    defaultMessage: 'Sign in to continue.',
+    description: 'Message show to learners when their account has been activated successfully',
+  },
+  'account.confirmation.info.message': {
+    id: 'account.confirmation.info.message',
+    defaultMessage: 'This email has already been confirmed.',
+    description: 'Message shown when learner account has already been verified',
+  },
+  'account.confirmation.error.message.title': {
+    id: 'account.confirmation.error.message.title',
+    defaultMessage: 'Your email could not be confirmed',
+    description: 'Account verification error message title',
   },
   'internal.server.error.message': {
     id: 'internal.server.error.message',

--- a/src/login/tests/AccountActivationMessage.test.jsx
+++ b/src/login/tests/AccountActivationMessage.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
+import { mergeConfig } from '@edx/frontend-platform';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 
 import AccountActivationMessage from '../AccountActivationMessage';
@@ -9,6 +10,12 @@ import { ACCOUNT_ACTIVATION_MESSAGE } from '../data/constants';
 const IntlAccountActivationMessage = injectIntl(AccountActivationMessage);
 
 describe('AccountActivationMessage', () => {
+  beforeEach(() => {
+    mergeConfig({
+      MARKETING_EMAILS_OPT_IN: '',
+    });
+  });
+
   it('should match account already activated message', () => {
     const accountActivationMessage = mount(
       <IntlProvider locale="en">
@@ -53,5 +60,47 @@ describe('AccountActivationMessage', () => {
     );
 
     expect(accountActivationMessage).toEqual({});
+  });
+});
+
+describe('EmailConfirmationMessage', () => {
+  beforeEach(() => {
+    mergeConfig({
+      MARKETING_EMAILS_OPT_IN: 'true',
+    });
+  });
+
+  it('should match email already confirmed message', () => {
+    const accountVerificationMessage = mount(
+      <IntlProvider locale="en">
+        <IntlAccountActivationMessage messageType={ACCOUNT_ACTIVATION_MESSAGE.INFO} />
+      </IntlProvider>,
+    );
+
+    const expectedMessage = 'This email has already been confirmed.';
+    expect(accountVerificationMessage.find('#account-activation-message').find('div').first().text()).toEqual(expectedMessage);
+  });
+
+  it('should match email confirmation success message', () => {
+    const accountVerificationMessage = mount(
+      <IntlProvider locale="en">
+        <IntlAccountActivationMessage messageType={ACCOUNT_ACTIVATION_MESSAGE.SUCCESS} />
+      </IntlProvider>,
+    );
+
+    const expectedMessage = 'Success! You have confirmed your email.Sign in to continue.';
+    expect(accountVerificationMessage.find('#account-activation-message').first().text()).toEqual(expectedMessage);
+  });
+
+  it('should match email confirmation error message', () => {
+    const accountVerificationMessage = mount(
+      <IntlProvider locale="en">
+        <IntlAccountActivationMessage messageType={ACCOUNT_ACTIVATION_MESSAGE.ERROR} />
+      </IntlProvider>,
+    );
+
+    const expectedMessage = 'Your email could not be confirmed'
+                            + 'Something went wrong, please contact support to resolve this issue.';
+    expect(accountVerificationMessage.find('#account-activation-message').first().text()).toEqual(expectedMessage);
   });
 });

--- a/src/login/tests/LoginPage.test.jsx
+++ b/src/login/tests/LoginPage.test.jsx
@@ -215,8 +215,8 @@ describe('LoginPage', () => {
 
   it('should match account activation message', () => {
     const activationMessage = 'Success! You have activated your account.'
-      + 'You will now receive email updates and alerts from us related '
-      + 'to the courses you are enrolled in. Sign in to continue.';
+                              + 'You will now receive email updates and alerts from us related '
+                              + 'to the courses you are enrolled in. Sign in to continue.';
 
     delete window.location;
     window.location = { href: getConfig().BASE_URL.concat('/login'), search: '?account_activation_status=success' };

--- a/src/register/messages.jsx
+++ b/src/register/messages.jsx
@@ -34,7 +34,7 @@ const messages = defineMessages({
   },
   'registration.opt.in.label': {
     id: 'registration.opt.in.label',
-    defaultMessage: 'By creating an account, I agree that {siteName} may send me marketing messages.',
+    defaultMessage: 'I agree that {siteName} may send me marketing messages.',
     description: 'Text for opt in option on register page.',
   },
   // Help text


### PR DESCRIPTION
As part of removing account activation step, we have repurposed the account activation email to account verification email. Following PR updates the success, error and information messages once the link has been clicked given in the email.

||Success|Info|Error|
|----|----|----|----|
OLD|<img width="780" alt="Screenshot 2021-11-10 at 5 19 44 PM" src="https://user-images.githubusercontent.com/40633976/141293546-f8e68624-9a8e-4f1c-adfa-2a9ade15bf89.png">|<img width="780" alt="Screenshot 2021-11-10 at 5 20 04 PM" src="https://user-images.githubusercontent.com/40633976/141293562-d29a79dc-6282-49b7-9c35-feb2714b764d.png">|<img width="780" alt="Screenshot 2021-11-10 at 5 19 56 PM" src="https://user-images.githubusercontent.com/40633976/141293557-eb73a09c-4404-469a-a236-924017bbbc2e.png">|
NEW|<img width="614" alt="Screenshot 2021-11-19 at 4 35 13 PM" src="https://user-images.githubusercontent.com/40633976/142617063-60557836-85f0-4289-bd76-42045343fee5.png">|<img width="614" alt="Screenshot 2021-11-19 at 4 34 58 PM" src="https://user-images.githubusercontent.com/40633976/142617045-68a78fd9-d10d-4e27-8660-e59c321ce047.png">|<img width="614" alt="Screenshot 2021-11-19 at 4 35 06 PM" src="https://user-images.githubusercontent.com/40633976/142617058-445a1bca-5758-4e07-abd1-ca5fe9395d5a.png">




Ticket: https://openedx.atlassian.net/browse/VAN-767