### PR TITLE
fix: remove aol domain from email provider list

### DIFF
--- a/src/register/data/constants.js
+++ b/src/register/data/constants.js
@@ -35,10 +35,10 @@ export const GENDER_OPTIONS = ['', 'f', 'm', 'o'];
 export const FORM_FIELDS = ['name', 'email', 'password', 'username', 'country'];
 
 export const COMMON_EMAIL_PROVIDERS = [
-  'hotmail.com', 'yahoo.com', 'outlook.com', 'live.com', 'gmail.com', 'aol.com',
+  'hotmail.com', 'yahoo.com', 'outlook.com', 'live.com', 'gmail.com',
 ];
 
-export const DEFAULT_SERVICE_PROVIDER_DOMAINS = ['yahoo', 'aol', 'hotmail', 'live', 'outlook', 'gmail'];
+export const DEFAULT_SERVICE_PROVIDER_DOMAINS = ['yahoo', 'hotmail', 'live', 'outlook', 'gmail'];
 
 export const DEFAULT_TOP_LEVEL_DOMAINS = [
   'aaa', 'aarp', 'abarth', 'abb', 'abbott', 'abbvie', 'abc', 'able', 'abogado', 'abudhabi', 'ac', 'academy',


### PR DESCRIPTION
### https://openedx.atlassian.net/browse/VAN-732
### Description
Remove the Confusion for any new users who still have an msn.com email address.

### Before fix:
<img width="528" alt="Screenshot 2021-11-16 at 6 32 21 PM" src="https://user-images.githubusercontent.com/7627421/141994741-4020fedb-10d1-4477-96de-3ffc71dfeb1b.png">

### After Fix:
<img width="553" alt="Screenshot 2021-11-16 at 6 30 15 PM" src="https://user-images.githubusercontent.com/7627421/141994794-6d39ab7a-3cb2-4260-a08f-aeedb41dcb7a.png">


